### PR TITLE
Add a "Dry Run" feature to the Agent form.

### DIFF
--- a/app/assets/javascripts/components/utils.js.coffee
+++ b/app/assets/javascripts/components/utils.js.coffee
@@ -12,3 +12,24 @@ class @Utils
         window.currentPage = new klass()
     else
       new klass()
+
+  @showDynamicModal: (content = '', { title, body, onHide } = {}) ->
+    $("body").append """
+      <div class="modal fade" tabindex="-1" id='dynamic-modal' role="dialog" aria-labelledby="dynamic-modal-label" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+              <h4 class="modal-title" id="dynamic-modal-label"></h4>
+            </div>
+            <div class="modal-body">#{content}</div>
+          </div>
+        </div>
+      </div>
+      """
+    modal = document.querySelector('#dynamic-modal')
+    $(modal).find('.modal-title').text(title || '').end().on 'hidden.bs.modal', ->
+      $('#dynamic-modal').remove()
+      onHide?()
+    body?(modal.querySelector('.modal-body'))
+    $(modal).modal('show')

--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -8,6 +8,9 @@ class @AgentEditPage
       $("#agent_type").on "change", => @handleTypeChange(false)
       @handleTypeChange(true)
 
+    unless $('agent-dry-run-button').prop('disabled')
+      @enableDryRunButton()
+
   handleTypeChange: (firstTime) ->
     $(".event-descriptions").html("").hide()
     type = $('#agent_type').val()
@@ -49,6 +52,11 @@ class @AgentEditPage
           $('.oauthable-form').html(json.oauthable) if json.oauthable?
           $('.agent-options').html(json.form_options) if json.form_options?
           window.jsonEditor = setupJsonEditor()[0]
+
+        if json.can_dry_run
+          @enableDryRunButton()
+        else
+          @disableDryRunButton()
 
         window.initializeFormCompletable()
 
@@ -121,6 +129,48 @@ class @AgentEditPage
         @showEventCreation()
       else
         @hideEventCreation()
+
+  enableDryRunButton: ->
+    $(".agent-dry-run-button").prop('disabled', false).off().on "click", @invokeDryRun
+
+  disableDryRunButton: ->
+    $(".agent-dry-run-button").prop('disabled', true)
+
+  invokeDryRun: (e) ->
+    e.preventDefault()
+    $(".agent-dry-run-button").prop('disabled', true)
+    $('body').css(cursor: 'progress')
+    $.ajax type: 'POST', url: $(".agent-dry-run-button").data('action-url'), dataType: 'json', data: $(@form).serialize()
+      .done (json) =>
+        $("body").css(cursor: 'auto').append """
+          <div class="modal fade" tabindex="-1" id='dynamic-modal' role="dialog" aria-labelledby="dynamic-modal-label" aria-hidden="true">
+            <div class="modal-dialog modal-lg">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                  <h4 class="modal-title" id="dynamic-modal-label"></h4>
+                </div>
+                <div class="modal-body">
+                  <h5>Log</h5>
+                  <pre class="agent-dry-run-log"></pre>
+                  <h5>Events</h5>
+                  <pre class="agent-dry-run-events"></pre>
+                  <h5>Memory</h5>
+                  <pre class="agent-dry-run-memory"></pre>
+                </div>
+              </div>
+            </div>
+          </div>
+        """
+        $('#dynamic-modal').find('.modal-title').text "Dry Run Results"
+        $('#dynamic-modal').find('.modal-body').
+          find('.agent-dry-run-log').text(json.log).end().
+          find('.agent-dry-run-events').text(json.events).end().
+          find('.agent-dry-run-memory').text(json.memory)
+        $('#dynamic-modal').modal('show').on 'hidden.bs.modal', ->
+          $('#dynamic-modal').remove()
+          $(".agent-dry-run-button").prop('disabled', false)
+        $(".agent-dry-run-button").prop('disabled', false)
 
 $ ->
   Utils.registerPage(AgentEditPage, forPathsMatching: /^agents/)

--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -141,8 +141,10 @@ class @AgentEditPage
     $(".agent-dry-run-button").prop('disabled', true)
     $('body').css(cursor: 'progress')
     $.ajax type: 'POST', url: $(".agent-dry-run-button").data('action-url'), dataType: 'json', data: $(@form).serialize()
+      .always =>
+        $("body").css(cursor: 'auto')
       .done (json) =>
-        $("body").css(cursor: 'auto').append """
+        $("body").append """
           <div class="modal fade" tabindex="-1" id='dynamic-modal' role="dialog" aria-labelledby="dynamic-modal-label" aria-hidden="true">
             <div class="modal-dialog modal-lg">
               <div class="modal-content">
@@ -170,6 +172,8 @@ class @AgentEditPage
         $('#dynamic-modal').modal('show').on 'hidden.bs.modal', ->
           $('#dynamic-modal').remove()
           $(".agent-dry-run-button").prop('disabled', false)
+      .fail (xhr, status, error) =>
+        alert('Error: ' + error)
         $(".agent-dry-run-button").prop('disabled', false)
 
 $ ->

--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -7,8 +7,7 @@ class @AgentEditPage
     if $("#agent_type").length
       $("#agent_type").on "change", => @handleTypeChange(false)
       @handleTypeChange(true)
-
-    unless $('agent-dry-run-button').prop('disabled')
+    else
       @enableDryRunButton()
 
   handleTypeChange: (firstTime) ->
@@ -53,10 +52,7 @@ class @AgentEditPage
           $('.agent-options').html(json.form_options) if json.form_options?
           window.jsonEditor = setupJsonEditor()[0]
 
-        if json.can_dry_run
-          @enableDryRunButton()
-        else
-          @disableDryRunButton()
+        @enableDryRunButton()
 
         window.initializeFormCompletable()
 
@@ -138,9 +134,10 @@ class @AgentEditPage
 
   invokeDryRun: (e) ->
     e.preventDefault()
-    $(".agent-dry-run-button").prop('disabled', true)
+    button = this
+    $(button).prop('disabled', true)
     $('body').css(cursor: 'progress')
-    $.ajax type: 'POST', url: $(".agent-dry-run-button").data('action-url'), dataType: 'json', data: $(@form).serialize()
+    $.ajax type: 'POST', url: $(button).data('action-url'), dataType: 'json', data: $(button.form).serialize()
       .always =>
         $("body").css(cursor: 'auto')
       .done (json) =>
@@ -171,10 +168,10 @@ class @AgentEditPage
           find('.agent-dry-run-memory').text(json.memory)
         $('#dynamic-modal').modal('show').on 'hidden.bs.modal', ->
           $('#dynamic-modal').remove()
-          $(".agent-dry-run-button").prop('disabled', false)
-      .fail (xhr, status, error) =>
+          $(button).prop('disabled', false)
+      .fail (xhr, status, error) ->
         alert('Error: ' + error)
-        $(".agent-dry-run-button").prop('disabled', false)
+        $(button).prop('disabled', false)
 
 $ ->
   Utils.registerPage(AgentEditPage, forPathsMatching: /^agents/)

--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -141,34 +141,21 @@ class @AgentEditPage
       .always =>
         $("body").css(cursor: 'auto')
       .done (json) =>
-        $("body").append """
-          <div class="modal fade" tabindex="-1" id='dynamic-modal' role="dialog" aria-labelledby="dynamic-modal-label" aria-hidden="true">
-            <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                  <h4 class="modal-title" id="dynamic-modal-label"></h4>
-                </div>
-                <div class="modal-body">
-                  <h5>Log</h5>
-                  <pre class="agent-dry-run-log"></pre>
-                  <h5>Events</h5>
-                  <pre class="agent-dry-run-events"></pre>
-                  <h5>Memory</h5>
-                  <pre class="agent-dry-run-memory"></pre>
-                </div>
-              </div>
-            </div>
-          </div>
-        """
-        $('#dynamic-modal').find('.modal-title').text "Dry Run Results"
-        $('#dynamic-modal').find('.modal-body').
-          find('.agent-dry-run-log').text(json.log).end().
-          find('.agent-dry-run-events').text(json.events).end().
-          find('.agent-dry-run-memory').text(json.memory)
-        $('#dynamic-modal').modal('show').on 'hidden.bs.modal', ->
-          $('#dynamic-modal').remove()
-          $(button).prop('disabled', false)
+        Utils.showDynamicModal """
+          <h5>Log</h5>
+          <pre class="agent-dry-run-log"></pre>
+          <h5>Events</h5>
+          <pre class="agent-dry-run-events"></pre>
+          <h5>Memory</h5>
+          <pre class="agent-dry-run-memory"></pre>
+          """,
+          body: (body) ->
+            $(body).
+              find('.agent-dry-run-log').text(json.log).end().
+              find('.agent-dry-run-events').text(json.events).end().
+              find('.agent-dry-run-memory').text(json.memory)
+          title: 'Dry Run Results',
+          onHide: -> $(button).prop('disabled', false)
       .fail (xhr, status, error) ->
         alert('Error: ' + error)
         $(button).prop('disabled', false)

--- a/app/assets/javascripts/pages/agent-show-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-show-page.js.coffee
@@ -19,22 +19,10 @@ class @AgentShowPage
         $button = $(this)
         $button.on 'click', (e) ->
           e.preventDefault()
-          $("body").append """
-            <div class="modal fade" tabindex="-1" id='dynamic-modal' role="dialog" aria-labelledby="dynamic-modal-label" aria-hidden="true">
-              <div class="modal-dialog modal-lg">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <h4 class="modal-title" id="dynamic-modal-label"></h4>
-                  </div>
-                  <div class="modal-body"><pre></pre></div>
-                </div>
-              </div>
-            </div>
-          """
-          $('#dynamic-modal').find('.modal-title').text $button.data('modal-title')
-          $('#dynamic-modal').find('.modal-body pre').text $button.data('modal-content')
-          $('#dynamic-modal').modal('show').on 'hidden.bs.modal', -> $('#dynamic-modal').remove()
+          Utils.showDynamicModal '<pre></pre>',
+            title: $button.data('modal-title'),
+            body: (body) ->
+              $(body).find('pre').text $button.data('modal-content')
 
       $("#logs .spinner").stop(true, true).fadeOut ->
         $("#logs .refresh, #logs .clear").show()

--- a/app/concerns/dry_runnable.rb
+++ b/app/concerns/dry_runnable.rb
@@ -1,0 +1,62 @@
+module DryRunnable
+  def dry_run!
+    class << self
+      prepend Sandbox
+    end
+
+    log = StringIO.new
+    @dry_run_logger = Logger.new(log)
+    @dry_run_results = {
+      events: [],
+    }
+
+    begin
+      raise "#{short_type} does not support dry-run" unless can_dry_run?
+      check
+    rescue => e
+      error "Exception during dry-run. #{e.message}: #{e.backtrace.join("\n")}"
+    end
+
+    @dry_run_results.update(
+      memory: memory,
+      log: log.string,
+    )
+  end
+
+  module Sandbox
+    attr_accessor :results
+
+    def logger
+      @dry_run_logger
+    end
+
+    def save
+      valid?
+    end
+
+    def save!
+      save or raise ActiveRecord::RecordNotSaved
+    end
+
+    def log(message, options = {})
+      case options[:level] || 3
+      when 0..2
+        sev = Logger::DEBUG
+      when 3
+        sev = Logger::INFO
+      else
+        sev = Logger::ERROR
+      end
+
+      logger.log(sev, message)
+    end
+
+    def create_event(event_hash)
+      if can_create_events?
+        @dry_run_results[:events] << event_hash[:payload]
+      else
+        error "This Agent cannot create events!"
+      end
+    end
+  end
+end

--- a/app/concerns/dry_runnable.rb
+++ b/app/concerns/dry_runnable.rb
@@ -1,5 +1,7 @@
 module DryRunnable
   def dry_run!
+    readonly!
+
     class << self
       prepend Sandbox
     end

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -33,20 +33,41 @@ class AgentsController < ApplicationController
     end
   end
 
+  def dry_run
+    attrs = params[:agent]
+    if agent = current_user.agents.find_by(id: params[:id])
+      # PUT /agents/:id/dry_run
+      type = agent.type
+    else
+      # POST /agents/dry_run
+      type = attrs.delete(:type)
+    end
+    agent = Agent.build_for_type(type, current_user, attrs)
+    agent.name ||= '(Untitled)'
+    results = agent.dry_run!
+
+    render json: {
+        log: results[:log],
+        events: Utils.pretty_print(results[:events], false),
+        memory: Utils.pretty_print(results[:memory] || {}, false),
+    }
+  end
+
   def type_details
     @agent = Agent.build_for_type(params[:type], current_user, {})
     initialize_presenter
 
-    render :json => {
-        :can_be_scheduled => @agent.can_be_scheduled?,
-        :default_schedule => @agent.default_schedule,
-        :can_receive_events => @agent.can_receive_events?,
-        :can_create_events => @agent.can_create_events?,
-        :can_control_other_agents => @agent.can_control_other_agents?,
-        :options => @agent.default_options,
-        :description_html => @agent.html_description,
-        :oauthable => render_to_string(partial: 'oauth_dropdown', locals: { agent: @agent }),
-        :form_options => render_to_string(partial: 'options', locals: { agent: @agent })
+    render json: {
+        can_be_scheduled: @agent.can_be_scheduled?,
+        default_schedule: @agent.default_schedule,
+        can_receive_events: @agent.can_receive_events?,
+        can_create_events: @agent.can_create_events?,
+        can_control_other_agents: @agent.can_control_other_agents?,
+        can_dry_run: @agent.can_dry_run?,
+        options: @agent.default_options,
+        description_html: @agent.html_description,
+        oauthable: render_to_string(partial: 'oauth_dropdown', locals: { agent: @agent }),
+        form_options: render_to_string(partial: 'options', locals: { agent: @agent })
     }
   end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -12,6 +12,7 @@ class Agent < ActiveRecord::Base
   include LiquidInterpolatable
   include HasGuid
   include LiquidDroppable
+  include DryRunnable
 
   markdown_class_attributes :description, :event_description
 
@@ -194,6 +195,10 @@ class Agent < ActiveRecord::Base
     self.class.can_control_other_agents?
   end
 
+  def can_dry_run?
+    self.class.can_dry_run?
+  end
+
   def log(message, options = {})
     AgentLog.log_for_agent(self, message, options)
   end
@@ -326,6 +331,14 @@ class Agent < ActiveRecord::Base
 
     def can_control_other_agents?
       include? AgentControllerConcern
+    end
+
+    def can_dry_run!
+      @can_dry_run = true
+    end
+
+    def can_dry_run?
+      !!@can_dry_run
     end
 
     def gem_dependency_check

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -5,6 +5,8 @@ module Agents
   class WebsiteAgent < Agent
     include WebRequestConcern
 
+    can_dry_run!
+
     default_schedule "every_12h"
 
     UNIQUENESS_LOOK_BACK = 200

--- a/app/views/agents/_options.erb
+++ b/app/views/agents/_options.erb
@@ -24,5 +24,7 @@
 <% end %>
 <div class="form-group">
   <%= submit_tag "Save", :class => "btn btn-primary" %>
-  <%= button_tag class: 'btn btn-default agent-dry-run-button', type: 'button', disabled: !agent.can_dry_run?, 'data-action-url' => agent.persisted? ? dry_run_agent_path(agent) : dry_run_agents_path do %><%= icon_tag('glyphicon-refresh') %> Dry Run<% end %>
+  <% if agent.can_dry_run? %>
+    <%= button_tag class: 'btn btn-default agent-dry-run-button', type: 'button', 'data-action-url' => agent.persisted? ? dry_run_agent_path(agent) : dry_run_agents_path do %><%= icon_tag('glyphicon-refresh') %> Dry Run<% end %>
+  <% end %>
 </div>

--- a/app/views/agents/_options.erb
+++ b/app/views/agents/_options.erb
@@ -24,4 +24,5 @@
 <% end %>
 <div class="form-group">
   <%= submit_tag "Save", :class => "btn btn-primary" %>
+  <%= button_tag class: 'btn btn-default agent-dry-run-button', type: 'button', disabled: !agent.can_dry_run?, 'data-action-url' => agent.persisted? ? dry_run_agent_path(agent) : dry_run_agents_path do %><%= icon_tag('glyphicon-refresh') %> Dry Run<% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Huginn::Application.routes.draw do
   resources :agents do
     member do
       post :run
+      put :dry_run
       post :handle_details_post
       put :leave_scenario
       delete :remove_events
@@ -10,6 +11,7 @@ Huginn::Application.routes.draw do
     collection do
       post :propagate
       get :type_details
+      post :dry_run
       get :event_descriptions
       post :validate
       post :complete

--- a/spec/concerns/dry_runnable_spec.rb
+++ b/spec/concerns/dry_runnable_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe DryRunnable do
+  class Agents::SandboxedAgent < Agent
+    default_schedule "3pm"
+
+    can_dry_run!
+
+    def check
+      log "Logging"
+      create_event payload: { test: "foo" }
+      error "Recording error"
+      create_event payload: { test: "bar" }
+      self.memory = { last_status: "ok" }
+      save!
+    end
+  end
+
+  before do
+    stub(Agents::SandboxedAgent).valid_type?("Agents::SandboxedAgent") { true }
+
+    @agent = Agents::SandboxedAgent.create(name: "some agent") { |agent|
+      agent.user = users(:bob)
+    }
+  end
+
+  it "traps logging, event emission and memory updating" do
+    results = nil
+
+    expect {
+      results = @agent.dry_run!
+    }.not_to change {
+      [users(:bob).agents.count, users(:bob).events.count, users(:bob).logs.count]
+    }
+
+    expect(results[:log]).to match(/\AI, .+ INFO -- : Logging\nE, .+ ERROR -- : Recording error\n/)
+    expect(results[:events]).to eq([{ test: 'foo' }, { test: 'bar' }])
+    expect(results[:memory]).to eq({ "last_status" => "ok" })
+  end
+
+  it "does not perform dry-run if Agent does not support dry-run" do
+    stub(@agent).can_dry_run? { false }
+
+    results = nil
+
+    expect {
+      results = @agent.dry_run!
+    }.not_to change {
+      [users(:bob).agents.count, users(:bob).events.count, users(:bob).logs.count]
+    }
+
+    expect(results[:log]).to match(/\AE, .+ ERROR -- : Exception during dry-run. SandboxedAgent does not support dry-run: /)
+    expect(results[:events]).to eq([])
+    expect(results[:memory]).to eq({})
+  end
+end

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -347,4 +347,31 @@ describe AgentsController do
       end
     end
   end
+
+  describe "POST dry_run" do
+    it "does not actually create any agent, event or log" do
+      sign_in users(:bob)
+      expect {
+        post :dry_run, agent: valid_attributes()
+      }.not_to change {
+        [users(:bob).agents.count, users(:bob).events.count, users(:bob).logs.count]
+      }
+      json = JSON.parse(response.body)
+      expect(json['log']).to be_a(String)
+      expect(json['events']).to be_a(String)
+      expect(JSON.parse(json['events']).map(&:class)).to eq([Hash])
+      expect(json['memory']).to be_a(String)
+      expect(JSON.parse(json['memory'])).to be_a(Hash)
+    end
+
+    it "does not actually update an agent" do
+      sign_in users(:bob)
+      agent = agents(:bob_weather_agent)
+      expect {
+        post :dry_run, id: agents(:bob_website_agent), agent: valid_attributes(name: 'New Name')
+      }.not_to change {
+        [users(:bob).agents.count, users(:bob).events.count, users(:bob).logs.count, agent.name, agent.updated_at]
+      }
+    end
+  end
 end


### PR DESCRIPTION
User can test if an agent being saved will work as expected simply by clicking the "Dry Run" button, which opens up a modal window that shows dry-run results including log, events and memory.  Resolves #593.

The current implementation only allows dry-run of Agents that do not require an incoming event to be run.

Also, each Agent class must opt in for this feature by declaring themselves as `can_dry_run!`.  To begin with, only WebsiteAgent is marked as dry-runnable for now.