### PR TITLE
[pushbullet] add support for further message types

### DIFF
--- a/app/models/agents/pushbullet_agent.rb
+++ b/app/models/agents/pushbullet_agent.rb
@@ -16,7 +16,13 @@ module Agents
 
       Put one of the retured `iden` strings into the `device_id` field.
 
-      You can provide a `title` and a `body`.
+      You have to provide a message `type` which has to be `note`, `link`, or `address`. The message types `checklist`, and `file` are not supported at the moment.
+
+      Depending on the message `type` you can use additional fields:
+
+      * note: `title` and `body`
+      * link: `title`, `body`, and `url`
+      * address: `name`, and `address`
 
       In every value of the options hash you can use the liquid templating, learn more about it at the [Wiki](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid).
     MD
@@ -25,14 +31,16 @@ module Agents
       {
         'api_key' => '',
         'device_id' => '',
-        'title' => "Hello from Huginn!",
+        'title' => "{{title}}",
         'body' => '{{body}}',
+        'type' => 'note',
       }
     end
 
     def validate_options
       errors.add(:base, "you need to specify a pushbullet api_key") unless options['api_key'].present?
       errors.add(:base, "you need to specify a device_id") if options['device_id'].blank?
+      errors.add(:base, "you need to specify a valid message type") if options['type'].blank? or not ['note', 'link', 'address'].include?(options['type'])
     end
 
     def working?
@@ -50,9 +58,21 @@ module Agents
 
     def query_options(event)
       mo = interpolated(event)
+      body = {:device_iden => mo[:device_id], :type => mo[:type]}
+      if mo[:type] == "note"
+        body[:title] = mo[:title]
+        body[:body] = mo[:body]
+      elsif mo[:type] == "link"
+        body[:title] = mo[:title]
+        body[:body] = mo[:body]
+        body[:url] = mo[:url]
+      elsif mo[:type] == "address"
+        body[:name] = mo[:name]
+        body[:address] = mo[:address]
+      end
       {
         :basic_auth => {:username => mo[:api_key], :password => ''},
-        :body => {:device_iden => mo[:device_id], :title => mo[:title], :body => mo[:body], :type => 'note'}
+        :body => body
       }
     end
   end


### PR DESCRIPTION
There are more usable message types documented at
https://docs.pushbullet.com/v2/pushes/.