### PR TITLE
allow toggling between circles and points in recent event map

### DIFF
--- a/app/assets/javascripts/map_marker.js.coffee
+++ b/app/assets/javascripts/map_marker.js.coffee
@@ -2,7 +2,7 @@ window.map_marker = (map, options = {}) ->
   pos = new google.maps.LatLng(options.lat, options.lng)
 
   if options.radius > 0
-    new google.maps.Circle
+    marker = new google.maps.Circle
       map: map
       strokeColor: '#FF0000'
       strokeOpacity: 0.8
@@ -11,11 +11,13 @@ window.map_marker = (map, options = {}) ->
       fillOpacity: 0.35
       center: pos
       radius: options.radius
+    return marker
   else
-    new google.maps.Marker
+    marker = new google.maps.Marker
       map: map
       position: pos
       title: 'Recorded Location'
+    return marker
 
   if options.course
     p1 = new LatLon(pos.lat(), pos.lng())
@@ -30,7 +32,7 @@ window.map_marker = (map, options = {}) ->
     lineSymbol =
       path: google.maps.SymbolPath.FORWARD_CLOSED_ARROW
 
-    new google.maps.Polyline
+    arrow = new google.maps.Polyline
       map: map
       path: lineCoordinates
       icons: [
@@ -39,3 +41,5 @@ window.map_marker = (map, options = {}) ->
           offset: '100%'
         }
       ]
+    
+    return arrow

--- a/app/assets/javascripts/map_marker.js.coffee
+++ b/app/assets/javascripts/map_marker.js.coffee
@@ -41,5 +41,5 @@ window.map_marker = (map, options = {}) ->
           offset: '100%'
         }
       ]
-    
+
     return arrow

--- a/app/views/agents/agent_views/user_location_agent/_show.html.erb
+++ b/app/views/agents/agent_views/user_location_agent/_show.html.erb
@@ -47,6 +47,9 @@
                 Visibility(points, map);
             }
         });
+        if(circles.length > 0){
+            $(".checkbox").removeClass("hidden");
+        }
     });
 
   </script>
@@ -56,7 +59,7 @@
   </p>
 <% end %>
 
-<div class="checkbox">
+<div class="hidden checkbox">
     <label>
         <input id="toggle" type="checkbox" value="">
         Show accuracy of locations

--- a/app/views/agents/agent_views/user_location_agent/_show.html.erb
+++ b/app/views/agents/agent_views/user_location_agent/_show.html.erb
@@ -28,27 +28,27 @@
     points.push(map_marker(map, loc));
     <% end %>
 
-    function Visibility(group, map) {
+    function toggleAccuracy(group, map) {
         for (var i = 0; i < group.length; i++) {
             group[i].setMap(map);
         }
     }
 
-    Visibility(circles, null);
+    toggleAccuracy(circles, null);
 
     $(document).ready(function() {
         $("input#toggle").on("click", function() {
             if($(this).is(":checked")){
-                Visibility(circles, map);
-                Visibility(points, null);
+                toggleAccuracy(circles, map);
+                toggleAccuracy(points, null);
             }
-            else if($(this).is(":not(:checked)")){
-                Visibility(circles, null);
-                Visibility(points, map);
+            else {
+                toggleAccuracy(circles, null);
+                toggleAccuracy(points, map);
             }
         });
         if(circles.length > 0){
-            $(".checkbox").removeClass("hidden");
+            $(".toggle-accuracy").removeClass("hidden");
         }
     });
 
@@ -59,7 +59,7 @@
   </p>
 <% end %>
 
-<div class="hidden checkbox">
+<div class="hidden toggle-accuracy checkbox">
     <label>
         <input id="toggle" type="checkbox" value="">
         Show accuracy of locations

--- a/app/views/agents/agent_views/user_location_agent/_show.html.erb
+++ b/app/views/agents/agent_views/user_location_agent/_show.html.erb
@@ -17,15 +17,51 @@
     };
 
     var map = new google.maps.Map(document.getElementById("map_canvas"), mapOptions);
+    var circles = [];
+    var points = [];
     <% events.each do |event| %>
-    map_marker(map, <%= Utils.jsonify(event.location) %>);
+    var loc = <%= Utils.jsonify(event.location) %>;
+    if (loc.radius > 1) {
+        circles.push(map_marker(map, loc));
+    }
+    delete loc.radius;
+    points.push(map_marker(map, loc));
     <% end %>
+
+    function Visibility(group, map) {
+        for (var i = 0; i < group.length; i++) {
+            group[i].setMap(map);
+        }
+    }
+
+    Visibility(circles, null);
+
+    $(document).ready(function() {
+        $("input#toggle").on("click", function() {
+            if($(this).is(":checked")){
+                Visibility(circles, map);
+                Visibility(points, null);
+            }
+            else if($(this).is(":not(:checked)")){
+                Visibility(circles, null);
+                Visibility(points, map);
+            }
+        });
+    });
+
   </script>
 <% else %>
   <p>
     No events found.
   </p>
 <% end %>
+
+<div class="checkbox">
+    <label>
+        <input id="toggle" type="checkbox" value="">
+        Show accuracy of locations
+    </label>
+</div>
 
 <h3>POST URL</h3>
 
@@ -36,3 +72,4 @@
     <li><code class="selectable-text"><%= web_requests_url(user_id: @agent.user_id, agent_id: @agent.id, secret: @agent.options['secret']) %></code></li>
   </ul>
 </p>
+<p>The data can also include <code>radius</code>, <code>speed</code>, and <code>course</code> values.</p>


### PR DESCRIPTION
This adds a checkbox to toggle between circles showing location with an accuracy radius and points showing the center of that range, which resolves #670.