### PR TITLE
allow custom icon for slack webhooks

### DIFF
--- a/app/models/agents/slack_agent.rb
+++ b/app/models/agents/slack_agent.rb
@@ -72,9 +72,9 @@ module Agents
       incoming_events.each do |event|
         opts = interpolated(event)
         if /^:/.match(opts[:icon])
-            slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username], icon_emoji: opts[:icon]
+          slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username], icon_emoji: opts[:icon]
         else
-            slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username], icon_url: opts[:icon]
+          slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username], icon_url: opts[:icon]
         end
       end
     end

--- a/app/models/agents/slack_agent.rb
+++ b/app/models/agents/slack_agent.rb
@@ -20,7 +20,10 @@ module Agents
       Once the webhook has been setup it can be used to post to other channels or ping team members.
       To send a private message to team-mate, assign his username as `@username` to the channel option.
       To communicate with a different webhook on slack, assign your custom webhook name to the webhook option.
-      Messages can also be formatted using [Liquid](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid)
+      Messages can also be formatted using [Liquid](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid).
+
+      Finally, you can set a custom icon for this webhook in `icon`, either as [emoji](http://unicodey.com/emoji-data/table.htm) or an URL to an image.
+      Leaving this field blank will use the default icon for a webhook.
     MD
 
     def default_options
@@ -29,6 +32,7 @@ module Agents
         'channel' => '#general',
         'username' => DEFAULT_USERNAME,
         'message' => "Hey there, It's Huginn",
+        'icon' => '',
       }
     end
 
@@ -67,7 +71,11 @@ module Agents
     def receive(incoming_events)
       incoming_events.each do |event|
         opts = interpolated(event)
-        slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username]
+        if /^:/.match(opts[:icon])
+            slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username], icon_emoji: opts[:icon]
+        else
+            slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username], icon_url: opts[:icon]
+        end
       end
     end
   end

--- a/spec/models/agents/slack_agent_spec.rb
+++ b/spec/models/agents/slack_agent_spec.rb
@@ -33,6 +33,17 @@ describe Agents::SlackAgent do
       @checker.options['channel'] = nil
       expect(@checker).not_to be_valid
     end
+
+    it "should allow an icon" do
+      @checker.options['icon_emoji'] = nil
+      expect(@checker).to be_valid
+      @checker.options['icon_emoji'] = ":something:"
+      expect(@checker).to be_valid
+      @checker.options['icon_url'] = "http://something.com/image.png"
+      expect(@checker).to be_valid
+      @checker.options['icon_emoji'] = "something"
+      expect(@checker).to be_valid
+    end
   end
 
   describe "#receive" do


### PR DESCRIPTION
I'm not sure if I did this the most efficient way, but it works. This lets a user set either emoji or an image at an URL as the icon for the webhook into Slack.