### PR TITLE
add max_accuracy option in location agent

### DIFF
--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -73,7 +73,10 @@ module Agents
     def handle_payload(payload)
       location = Location.new(payload)
 
-      if location.present? && (!interpolated[:max_accuracy].present? || payload["accuracy"] < interpolated[:max_accuracy])
+      if location.present? && (!interpolated[:max_accuracy].present? || !payload["accuracy"] || payload["accuracy"] < interpolated[:max_accuracy])
+        if !payload["accuracy"]
+          log "Accuracy field missing; all locations will be kept"
+        end
         create_event payload: payload, location: location
       end
     end

--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -79,7 +79,7 @@ module Agents
         accuracy_field = 'accuracy'
       end
 
-      if location.present? && (!interpolated[:max_accuracy].present? || !payload[accuracy_field] || payload[accuracy_field] < interpolated[:max_accuracy])
+      if location.present? && (!interpolated[:max_accuracy].present? || !payload[accuracy_field] || payload[accuracy_field].to_i < interpolated[:max_accuracy].to_i)
         if !payload[accuracy_field]
           log "Accuracy field missing; all locations will be kept"
         end

--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -11,7 +11,7 @@ module Agents
 
         Your POST path will be `https://#{ENV['DOMAIN']}/users/#{user.id}/update_location/:secret` where `:secret` is specified in your options.
 
-        If you want to only keep more precise locations, set `max_accuracy` to the upper bound, in meters.
+        If you want to only keep more precise locations, set `max_accuracy` to the upper bound, in meters. The default name for this field is `accuracy`, but you can change this by setting a value for `accuracy_field`.
       MD
     end
 
@@ -73,8 +73,14 @@ module Agents
     def handle_payload(payload)
       location = Location.new(payload)
 
-      if location.present? && (!interpolated[:max_accuracy].present? || !payload["accuracy"] || payload["accuracy"] < interpolated[:max_accuracy])
-        if !payload["accuracy"]
+      if interpolated[:accuracy_field].present?
+        accuracy_field = interpolated[:accuracy_field]
+      else
+        accuracy_field = 'accuracy'
+      end
+
+      if location.present? && (!interpolated[:max_accuracy].present? || !payload[accuracy_field] || payload[accuracy_field] < interpolated[:max_accuracy])
+        if !payload[accuracy_field]
           log "Accuracy field missing; all locations will be kept"
         end
         create_event payload: payload, location: location

--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -10,6 +10,8 @@ module Agents
 
 
         Your POST path will be `https://#{ENV['DOMAIN']}/users/#{user.id}/update_location/:secret` where `:secret` is specified in your options.
+
+        If you want to only keep more precise locations, set `max_accuracy` to the upper bound, in meters.
       MD
     end
 
@@ -34,7 +36,10 @@ module Agents
     end
 
     def default_options
-      { 'secret' => SecureRandom.hex(7) }
+      {
+        'secret' => SecureRandom.hex(7),
+        'max_accuracy' => ''
+      }
     end
 
     def validate_options
@@ -68,7 +73,7 @@ module Agents
     def handle_payload(payload)
       location = Location.new(payload)
 
-      if location.present?
+      if (location.present? && (payload["accuracy"] < interpolated[:max_accuracy]))
         create_event payload: payload, location: location
       end
     end

--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -73,7 +73,7 @@ module Agents
     def handle_payload(payload)
       location = Location.new(payload)
 
-      if (location.present? && (payload["accuracy"] < interpolated[:max_accuracy]))
+      if location.present? && (!interpolated[:max_accuracy].present? || payload["accuracy"] < interpolated[:max_accuracy])
         create_event payload: payload, location: location
       end
     end

--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -73,14 +73,10 @@ module Agents
     def handle_payload(payload)
       location = Location.new(payload)
 
-      if interpolated[:accuracy_field].present?
-        accuracy_field = interpolated[:accuracy_field]
-      else
-        accuracy_field = 'accuracy'
-      end
+      accuracy_field = interpolated[:accuracy_field].presence || 'accuracy'
 
       if location.present? && (!interpolated[:max_accuracy].present? || !payload[accuracy_field] || payload[accuracy_field].to_i < interpolated[:max_accuracy].to_i)
-        if !payload[accuracy_field]
+        if interpolated[:max_accuracy].present? && !payload[accuracy_field].present?
           log "Accuracy field missing; all locations will be kept"
         end
         create_event payload: payload, location: location

--- a/spec/models/agents/user_location_agent_spec.rb
+++ b/spec/models/agents/user_location_agent_spec.rb
@@ -74,4 +74,20 @@ describe Agents::UserLocationAgent do
     expect(@agent.events.last.lat).to eq(45)
     expect(@agent.events.last.lng).to eq(123)
   end
+
+  it 'allows a custom accuracy field' do
+    event = Event.new
+    event.agent = agents(:bob_weather_agent)
+    event.created_at = Time.now
+    @agent.options['accuracy_field'] = 'estimated_to'
+    event.payload = { 'longitude' => 123, 'latitude' => 45, 'estimated_to' => '20', 'something' => 'else' }
+
+    expect {
+      @agent.receive([event])
+    }.to change { @agent.events.count }.by(1)
+
+    expect(@agent.events.last.payload).to eq({ 'longitude' => 123, 'latitude' => 45, 'estimated_to' => '20', 'something' => 'else' })
+    expect(@agent.events.last.lat).to eq(45)
+    expect(@agent.events.last.lng).to eq(123)
+  end
 end


### PR DESCRIPTION
With this, a user can define the upper bound of precision for keeping a location event. This doesn't yet handle the scenario where the option is not set, as I didn't know what the best way to do that would be.