### PR TITLE
Far enough

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'omniauth-tumblr'
 gem 'dropbox-api'
 gem 'omniauth-dropbox'
 
+# UserLocationAgent
+gem 'haversine'
+
 # Optional Services.
 gem 'omniauth-37signals'          # BasecampAgent
 # gem 'omniauth-github'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
       guard (~> 2.1)
       rspec (>= 2.14, < 4.0)
     hashie (2.0.5)
+    haversine (0.3.0)
     hike (1.2.3)
     hipchat (1.2.0)
       httparty
@@ -476,6 +477,7 @@ DEPENDENCIES
   guard
   guard-livereload
   guard-rspec
+  haversine
   hipchat (~> 1.2.0)
   httparty (~> 0.13)
   hypdf (~> 1.0.7)

--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -79,7 +79,7 @@ module Agents
     def handle_payload(payload)
       location = Location.new(payload)
 
-      accuracy_field = interpolated[:accuracy_field].presence || 'accuracy'
+      accuracy_field = interpolated[:accuracy_field].presence || "accuracy"
 
       def accurate_enough?(payload, accuracy_field)
         !interpolated[:max_accuracy].present? || !payload[accuracy_field] || payload[accuracy_field].to_i < interpolated[:max_accuracy].to_i

--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -13,6 +13,8 @@ module Agents
         Your POST path will be `https://#{ENV['DOMAIN']}/users/#{user.id}/update_location/:secret` where `:secret` is specified in your options.
 
         If you want to only keep more precise locations, set `max_accuracy` to the upper bound, in meters. The default name for this field is `accuracy`, but you can change this by setting a value for `accuracy_field`.
+
+        If you want to require a certain distance traveled, set `distance` to the minimum distance, in meters. Note that GPS readings and the measurement itself aren't exact, so don't rely on this for precision filtering.
       MD
     end
 

--- a/spec/models/agents/user_location_agent_spec.rb
+++ b/spec/models/agents/user_location_agent_spec.rb
@@ -6,7 +6,7 @@ describe Agents::UserLocationAgent do
                                   :name => 'something',
                                   :options => { :secret => 'my_secret',
                                     :max_accuracy => '50',
-                                    :distance => '50' })
+                                    :min_distance => '50' })
     @agent.save!
   end
 

--- a/spec/models/agents/user_location_agent_spec.rb
+++ b/spec/models/agents/user_location_agent_spec.rb
@@ -5,7 +5,8 @@ describe Agents::UserLocationAgent do
     @agent = Agent.build_for_type('Agents::UserLocationAgent', users(:bob),
                                   :name => 'something',
                                   :options => { :secret => 'my_secret',
-                                    :max_accuracy => '50' })
+                                    :max_accuracy => '50',
+                                    :distance => '50' })
     @agent.save!
   end
 
@@ -89,5 +90,33 @@ describe Agents::UserLocationAgent do
     expect(@agent.events.last.payload).to eq({ 'longitude' => 123, 'latitude' => 45, 'estimated_to' => '20', 'something' => 'else' })
     expect(@agent.events.last.lat).to eq(45)
     expect(@agent.events.last.lng).to eq(123)
+  end
+
+  it 'does create an event when far enough' do
+    @agent.memory["last_location"] = { 'longitude' => 12, 'latitude' => 34, 'something' => 'else' }
+    event = Event.new
+    event.agent = agents(:bob_weather_agent)
+    event.created_at = Time.now
+    event.payload = { 'longitude' => 123, 'latitude' => 45, 'something' => 'else' }
+
+    expect {
+      @agent.receive([event])
+    }.to change { @agent.events.count }.by(1)
+
+    expect(@agent.events.last.payload).to eq({ 'longitude' => 123, 'latitude' => 45, 'something' => 'else' })
+    expect(@agent.events.last.lat).to eq(45)
+    expect(@agent.events.last.lng).to eq(123)
+  end
+
+  it 'does not create an event when too close' do
+    @agent.memory["last_location"] = { 'longitude' => 123, 'latitude' => 45, 'something' => 'else' }
+    event = Event.new
+    event.agent = agents(:bob_weather_agent)
+    event.created_at = Time.now
+    event.payload = { 'longitude' => 123, 'latitude' => 45, 'something' => 'else' }
+
+    expect {
+      @agent.receive([event])
+    }.to change { @agent.events.count }.by(0)
   end
 end


### PR DESCRIPTION
This allows an option to be set in UserLocationAgent to only keep locations that are at least a certain distance away from the previous location. It's not ultra-precise, but it will do the trick. This should help keep down the overall number of events, which is especially useful for free Heroku deploys.