### PR TITLE
Convert \n to actual line breaks after interpolating liquid

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -88,7 +88,7 @@ module LiquidInterpolatable
 
   def interpolate_string(string, self_object = nil)
     interpolate_with(self_object) do
-      Liquid::Template.parse(string).render!(interpolation_context)
+      Liquid::Template.parse(string).render!(interpolation_context).gsub('\n', "\n")
     end
   end
 

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -8,6 +8,17 @@ describe LiquidInterpolatable::Filters do
     end.new
   end
 
+  describe '#interpolate_string' do
+    before do
+      @agent = Agent.new
+    end
+
+    it 'should convert \n to line breaks' do
+      interpolated = @agent.send(:interpolate_string, '{{foo}}\n{{bar}}', Event.new(payload: {foo: 'test', bar: 'second line'}))
+      expect(interpolated).to eq("test\nsecond line")
+    end
+  end
+
   describe 'uri_escape' do
     it 'should escape a string for use in URI' do
       expect(@filter.uri_escape('abc:/?=')).to eq('abc%3A%2F%3F%3D')


### PR DESCRIPTION
This allows entering new line characters via `\n`for agents that do not use `FormConfigurable` and/or a text area to input the payload. I only tested it with the `HipchatAgent`, senarios to verify the patch is working are welcome. 

/cc @drbig @virtadpt