### PR TITLE
Added line_break tag to insert \n into liquid interpolated string

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -164,6 +164,13 @@ module LiquidInterpolatable
         credential
       end
     end
+
+    class LineBreak < Liquid::Tag
+      def render(context)
+        "\n"
+      end
+    end
   end
   Liquid::Template.register_tag('credential', LiquidInterpolatable::Tags::Credential)
+  Liquid::Template.register_tag('line_break', LiquidInterpolatable::Tags::LineBreak)
 end

--- a/spec/support/shared_examples/liquid_interpolatable.rb
+++ b/spec/support/shared_examples/liquid_interpolatable.rb
@@ -86,14 +86,22 @@ shared_examples_for LiquidInterpolatable do
   end
 
   describe "liquid tags" do
-    it "should work with existing credentials" do
-      expect(@checker.interpolate_string("{% credential aws_key %}", {})).to eq('2222222222-jane')
+    context "%credential" do
+      it "should work with existing credentials" do
+        expect(@checker.interpolate_string("{% credential aws_key %}", {})).to eq('2222222222-jane')
+      end
+
+      it "should raise an exception for undefined credentials" do
+        expect {
+          @checker.interpolate_string("{% credential unknown %}", {})
+        }.to raise_error
+      end
     end
 
-    it "should raise an exception for undefined credentials" do
-      expect {
-        @checker.interpolate_string("{% credential unknown %}", {})
-      }.to raise_error
+    context '%line_break' do
+      it 'should convert {% line_break %} to actual line breaks' do
+        expect(@checker.interpolate_string("test{% line_break %}second line", {})).to eq("test\nsecond line")
+      end
     end
   end
 end


### PR DESCRIPTION
Supersedes #707 

Using a custom tag to insert line breaks seems like a much cleaner approach to me, no clue why it did not work yesterday.

/cc @drbig @virtadpt