### PR TITLE
Pushbullet pull request unification

### DIFF
--- a/app/models/agents/pushbullet_agent.rb
+++ b/app/models/agents/pushbullet_agent.rb
@@ -3,6 +3,8 @@ module Agents
     cannot_be_scheduled!
     cannot_create_events!
 
+    API_URL = 'https://api.pushbullet.com/v2/pushes'
+
     description <<-MD
       The Pushbullet agent sends pushes to a pushbullet device
 
@@ -12,7 +14,7 @@ module Agents
 
       Currently you need to get a the device identification manually:
 
-      `curl -u <your api key here>: https://api.pushbullet.com/api/devices`
+      `curl -u <your api key here>: https://api.pushbullet.com/v2/devices`
 
       To register a new device run the following command:
 
@@ -53,7 +55,7 @@ module Agents
 
     def receive(incoming_events)
       incoming_events.each do |event|
-        response = HTTParty.post "https://api.pushbullet.com/api/pushes", query_options(event)
+        response = HTTParty.post API_URL, query_options(event)
         error(response.body) if response.body.include? 'error'
       end
     end

--- a/app/models/agents/pushbullet_agent.rb
+++ b/app/models/agents/pushbullet_agent.rb
@@ -44,7 +44,7 @@ module Agents
     end
 
     def validate_options
-      errors.add(:base, "you need to specify a pushbullet api_key") unless options['api_key'].present?
+      errors.add(:base, "you need to specify a pushbullet api_key") if options['api_key'].blank?
       errors.add(:base, "you need to specify a device_id") if options['device_id'].blank?
       errors.add(:base, "you need to specify a valid message type") if options['type'].blank? or not ['note', 'link', 'address'].include?(options['type'])
     end
@@ -64,15 +64,16 @@ module Agents
 
     def query_options(event)
       mo = interpolated(event)
-      body = {:device_iden => mo[:device_id], :type => mo[:type]}
-      if mo[:type] == "note"
+      body = {device_iden: mo[:device_id], type: mo[:type]}
+      case mo[:type]
+      when "note"
         body[:title] = mo[:title]
         body[:body] = mo[:body]
-      elsif mo[:type] == "link"
+      when "link"
         body[:title] = mo[:title]
         body[:body] = mo[:body]
         body[:url] = mo[:url]
-      elsif mo[:type] == "address"
+      when "address"
         body[:name] = mo[:name]
         body[:address] = mo[:address]
       end

--- a/app/models/agents/pushbullet_agent.rb
+++ b/app/models/agents/pushbullet_agent.rb
@@ -4,6 +4,11 @@ module Agents
     cannot_create_events!
 
     API_URL = 'https://api.pushbullet.com/v2/pushes'
+    TYPE_TO_ATTRIBUTES = {
+            'note'    => [:title, :body],
+            'link'    => [:title, :body, :url],
+            'address' => [:name, :address]
+    }
 
     description <<-MD
       The Pushbullet agent sends pushes to a pushbullet device
@@ -61,26 +66,16 @@ module Agents
     end
 
     private
-
     def query_options(event)
       mo = interpolated(event)
-      body = {device_iden: mo[:device_id], type: mo[:type]}
-      case mo[:type]
-      when "note"
-        body[:title] = mo[:title]
-        body[:body] = mo[:body]
-      when "link"
-        body[:title] = mo[:title]
-        body[:body] = mo[:body]
-        body[:url] = mo[:url]
-      when "address"
-        body[:name] = mo[:name]
-        body[:address] = mo[:address]
-      end
       {
-        :basic_auth => {:username => mo[:api_key], :password => ''},
-        :body => body
+        :basic_auth => {username: mo[:api_key], password: ''},
+        :body => {device_iden: mo[:device_id], type: mo[:type]}.merge(payload(mo))
       }
+    end
+
+    def payload(mo)
+      Hash[TYPE_TO_ATTRIBUTES[mo[:type]].map { |k| [k, mo[k]] }]
     end
   end
 end

--- a/app/models/agents/pushbullet_agent.rb
+++ b/app/models/agents/pushbullet_agent.rb
@@ -14,6 +14,10 @@ module Agents
 
       `curl -u <your api key here>: https://api.pushbullet.com/api/devices`
 
+      To register a new device run the following command:
+
+      `curl -u <your api key here>: -X POST https://api.pushbullet.com/v2/devices -d nickname=huginn -d type=stream`
+
       Put one of the retured `iden` strings into the `device_id` field.
 
       You can provide a `title` and a `body`.

--- a/app/models/agents/pushbullet_agent.rb
+++ b/app/models/agents/pushbullet_agent.rb
@@ -5,29 +5,22 @@ module Agents
     cannot_be_scheduled!
     cannot_create_events!
 
-    API_URL = 'https://api.pushbullet.com/v2/pushes'
+    API_BASE = 'https://api.pushbullet.com/v2/'
     TYPE_TO_ATTRIBUTES = {
             'note'    => [:title, :body],
             'link'    => [:title, :body, :url],
             'address' => [:name, :address]
     }
+    class Unauthorized < StandardError; end
 
     description <<-MD
       The Pushbullet agent sends pushes to a pushbullet device
 
-      To authenticate you need to set the `api_key`, you can find yours at your account page:
+      To authenticate you need to either the `api_key` or create a `pushbullet_api_key` credential, you can find yours at your account page:
 
       `https://www.pushbullet.com/account`
 
-      Currently you need to get a the device identification manually:
-
-      `curl -u <your api key here>: https://api.pushbullet.com/v2/devices`
-
-      To register a new device run the following command:
-
-      `curl -u <your api key here>: -X POST https://api.pushbullet.com/v2/devices -d nickname=huginn -d type=stream`
-
-      Put one of the retured `iden` strings into the `device_id` field.
+      If you do not select an existing device, Huginn will create a new one with the name 'Huginn'.
 
       You have to provide a message `type` which has to be `note`, `link`, or `address`. The message types `checklist`, and `file` are not supported at the moment.
 
@@ -50,8 +43,8 @@ module Agents
       }
     end
 
-    form_configurable :api_key
-    form_configurable :device_id
+    form_configurable :api_key, roles: :validatable
+    form_configurable :device_id, roles: :completable
     form_configurable :type, type: :array, values: ['note', 'link', 'address']
     form_configurable :title
     form_configurable :body, type: :text
@@ -61,11 +54,22 @@ module Agents
 
     def validate_options
       errors.add(:base, "you need to specify a pushbullet api_key") if options['api_key'].blank?
-      errors.add(:base, "you need to specify a device_id") if options['device_id'].blank?
+      create_device if options['device_id'].blank?
       errors.add(:base, "you need to specify a valid message type") if options['type'].blank? or not ['note', 'link', 'address'].include?(options['type'])
       TYPE_TO_ATTRIBUTES[options['type']].each do |attr|
         errors.add(:base, "you need to specify '#{attr.to_s}' for the type '#{options['type']}'") if options[attr].blank?
       end
+    end
+
+    def validate_api_key
+      devices
+      true
+    rescue Unauthorized
+      false
+    end
+
+    def complete_device_id
+      devices.map { |d| {text: d['nickname'], id: d['iden']} }
     end
 
     def working?
@@ -74,18 +78,47 @@ module Agents
 
     def receive(incoming_events)
       incoming_events.each do |event|
-        response = HTTParty.post API_URL, query_options(event)
-        error(response.body) if response.body.include? 'error'
+        safely do
+          response = request(:post, 'pushes', query_options(event))
+        end
       end
     end
 
     private
+    def safely
+      yield
+    rescue Unauthorized => e
+      error(e.message)
+    end
+
+    def request(http_method, method, options)
+      response = JSON.parse(HTTParty.send(http_method, API_BASE + method, options).body)
+      raise Unauthorized, response['error']['message'] if response['error'].present?
+      response
+    end
+
+    def devices
+      response = request(:get, 'devices', basic_auth)
+      response['devices'].select { |d| d['pushable'] == true }
+    rescue Unauthorized
+      []
+    end
+
+    def create_device
+      safely do
+        response = request(:post, 'devices', basic_auth.merge(body: {nickname: 'Huginn', type: 'stream'}))
+        self.options[:device_id] = response['iden']
+      end
+    end
+
+
+    def basic_auth
+      {basic_auth: {username: interpolated[:api_key].presence || credential('pushbullet_api_key'), password: ''}}
+    end
+
     def query_options(event)
       mo = interpolated(event)
-      {
-        basic_auth: {username: mo[:api_key], password: ''},
-        body: {device_iden: mo[:device_id], type: mo[:type]}.merge(payload(mo))
-      }
+      basic_auth.merge(body: {device_iden: mo[:device_id], type: mo[:type]}.merge(payload(mo)))
     end
 
     def payload(mo)

--- a/db/migrate/20150219213604_add_type_option_attribute_to_pushbullet_agents.rb
+++ b/db/migrate/20150219213604_add_type_option_attribute_to_pushbullet_agents.rb
@@ -1,0 +1,19 @@
+class AddTypeOptionAttributeToPushbulletAgents < ActiveRecord::Migration
+  def up
+    Agents::PushbulletAgent.all.each do |agent|
+      if agent.options['type'].nil?
+        agent.options['type'] = 'note'
+        agent.save!
+      end
+    end
+  end
+
+  def down
+    Agents::PushbulletAgent.all.each do |agent|
+      if agent.options['type'].present?
+        agent.options.delete 'type'
+        agent.save(validate: false)
+      end
+    end
+  end
+end

--- a/db/migrate/20150219213604_add_type_option_attribute_to_pushbullet_agents.rb
+++ b/db/migrate/20150219213604_add_type_option_attribute_to_pushbullet_agents.rb
@@ -1,6 +1,6 @@
 class AddTypeOptionAttributeToPushbulletAgents < ActiveRecord::Migration
   def up
-    Agents::PushbulletAgent.all.each do |agent|
+    Agents::PushbulletAgent.find_each do |agent|
       if agent.options['type'].nil?
         agent.options['type'] = 'note'
         agent.save!
@@ -9,7 +9,7 @@ class AddTypeOptionAttributeToPushbulletAgents < ActiveRecord::Migration
   end
 
   def down
-    Agents::PushbulletAgent.all.each do |agent|
+    Agents::PushbulletAgent.find_each do |agent|
       if agent.options['type'].present?
         agent.options.delete 'type'
         agent.save(validate: false)

--- a/spec/models/agents/pushbullet_agent_spec.rb
+++ b/spec/models/agents/pushbullet_agent_spec.rb
@@ -46,7 +46,7 @@ describe Agents::PushbulletAgent do
 
   describe "#receive" do
     it "send a message to the hipchat" do
-      stub_request(:post, "https://token:@api.pushbullet.com/api/pushes").
+      stub_request(:post, "https://token:@api.pushbullet.com/v2/pushes").
         with(:body => "device_iden=124&title=hello%20from%20huginn&body=One%20two%20test&type=note").
         to_return(:status => 200, :body => "ok", :headers => {})
       dont_allow(@checker).error
@@ -54,7 +54,7 @@ describe Agents::PushbulletAgent do
     end
 
     it "should log resquests which return an error" do
-      stub_request(:post, "https://token:@api.pushbullet.com/api/pushes").
+      stub_request(:post, "https://token:@api.pushbullet.com/v2/pushes").
         with(:body => "device_iden=124&title=hello%20from%20huginn&body=One%20two%20test&type=note").
         to_return(:status => 200, :body => "error", :headers => {})
       mock(@checker).error("error")

--- a/spec/models/agents/pushbullet_agent_spec.rb
+++ b/spec/models/agents/pushbullet_agent_spec.rb
@@ -35,8 +35,7 @@ describe Agents::PushbulletAgent do
 
     it "should try do create a device_id" do
       @checker.options['device_id'] = nil
-      mock(@checker).create_device
-      expect(@checker).to be_valid
+      expect(@checker).not_to be_valid
     end
 
     it "should require fields based on the type" do
@@ -142,6 +141,7 @@ describe Agents::PushbulletAgent do
       stub_request(:post, "https://token:@api.pushbullet.com/v2/devices").
          with(:body => "nickname=Huginn&type=stream").
          to_return(:status => 200, :body => '{"iden": "udm0Tdjz5A7bL4NM"}', :headers => {})
+      @checker.options['device_id'] = nil
       @checker.send(:create_device)
       expect(@checker.options[:device_id]).to eq('udm0Tdjz5A7bL4NM')
     end

--- a/spec/models/agents/pushbullet_agent_spec.rb
+++ b/spec/models/agents/pushbullet_agent_spec.rb
@@ -37,6 +37,12 @@ describe Agents::PushbulletAgent do
       @checker.options['device_id'] = nil
       expect(@checker).not_to be_valid
     end
+
+    it "should require fields based on the type" do
+      @checker.options['type'] = 'address'
+      @checker.options['address'] = nil
+      expect(@checker).not_to be_valid
+    end
   end
 
   describe "helpers" do


### PR DESCRIPTION
This supersedes #635, #636 and #640

I also added a migration for older `PushbulletAgent`s which only supported the `note` message type.

@berendt Thanks for the commits this is based on!