### PR TITLE
Add support to dropbox_file_url_agent for permanent links

### DIFF
--- a/app/models/agents/dropbox_file_url_agent.rb
+++ b/app/models/agents/dropbox_file_url_agent.rb
@@ -7,7 +7,7 @@ module Agents
     description <<-MD
       #{'## Include the `dropbox-api` and `omniauth-dropbox` gems in your `Gemfile` and set `DROPBOX_OAUTH_KEY` and `DROPBOX_OAUTH_SECRET` in your environment to use Dropbox Agents.' if dependencies_missing?}
       The _DropboxFileUrlAgent_ is used to work with Dropbox. It takes a file path (or multiple files paths) and emits
-      events with [temporary links](https://www.dropbox.com/developers/core/docs#media).
+      events with either [temporary links](https://www.dropbox.com/developers/core/docs#media) or [permanent links](https://www.dropbox.com/developers/core/docs#shares).
 
       The incoming event payload needs to have a `paths` key, with a comma-separated list of files you want the URL for. For example:
 
@@ -27,6 +27,8 @@ module Agents
 
       An example of usage would be to watch a specific Dropbox directory (with the _DropboxWatchAgent_) and get the URLs for the added or updated files. You could then, for example, send emails with those links.
 
+      Set `link_type` to `'temporary'` if you want temporary links, or to `'permanent'` for permanent ones.
+
     MD
 
     event_description <<-MD
@@ -38,19 +40,33 @@ module Agents
           }
     MD
 
+    def default_options
+      {
+        'link_type' => 'temporary'
+      }
+    end
+
     def working?
       !recent_error_logs?
     end
 
     def receive(events)
       events.map { |e| e.payload['paths'].split(',').map(&:strip) }
-        .flatten.each { |path| create_event payload: url_for(path) }
+        .flatten.each do |path|
+          create_event payload: (options['link_type'] == 'permanent' ? permanent_url_for(path) : temporary_url_for(path))
+        end
     end
 
     private
 
-    def url_for(path)
+    def temporary_url_for(path)
       dropbox.find(path).direct_url
+    end
+
+    def permanent_url_for(path)
+      result = dropbox.find(path).share_url({ :short_url => false })
+      result.url = result.url.gsub('?dl=0','?dl=1') # cause the url to point to the file, instead of to a preview page for the file
+      result
     end
 
   end


### PR DESCRIPTION
The dropbox urls returned by [a `/media` request](https://www.dropbox.com/developers/core/docs#media) only last a few hours. I added an option to the dropbox_file_url_agent to request [`/shares` urls](https://www.dropbox.com/developers/core/docs#shares), which last indefinitely. This takes advantage of the `?dl=1` query parameter, documented [here](https://www.dropbox.com/en/help/201).

I also just came across [this method](http://techapple.net/2014/04/trick-obtain-direct-download-links-dropbox-files-dropbox-direct-link-maker-tool-cloudlinker/) of getting permanent links, which seems like it might be better, even though it isn't documented on the dropbox website. What do you think?