### PR TITLE
Update agents_controller.rb

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -179,7 +179,9 @@ class AgentsController < ApplicationController
 
   # Sanitize params[:return] to prevent open redirect attacks, a common security issue.
   def redirect_back(message)
-    if params[:return] == "show" && @agent
+    if params[:return] == "show" && message.include?("deleted")
+      path = agents_path
+    elsif params[:return] == "show" && @agent
       path = agent_path(@agent)
     elsif params[:return] =~ /\A#{Regexp::escape scenarios_path}\/\d+\Z/
       path = params[:return]

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -179,9 +179,7 @@ class AgentsController < ApplicationController
 
   # Sanitize params[:return] to prevent open redirect attacks, a common security issue.
   def redirect_back(message)
-    if params[:return] == "show" && @agent.destroyed?
-      path = agents_path
-    elsif params[:return] == "show" && @agent
+    if params[:return] == "show" && @agent && !@agent.destroyed?
       path = agent_path(@agent)
     elsif params[:return] =~ /\A#{Regexp::escape scenarios_path}\/\d+\Z/
       path = params[:return]

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -179,7 +179,7 @@ class AgentsController < ApplicationController
 
   # Sanitize params[:return] to prevent open redirect attacks, a common security issue.
   def redirect_back(message)
-    if params[:return] == "show" && message.include?("deleted")
+    if params[:return] == "show" && @agent.destroyed?
       path = agents_path
     elsif params[:return] == "show" && @agent
       path = agent_path(@agent)


### PR DESCRIPTION
When user stay agent details page, user can use action.

When user use "Delete agent" action, then exception error is occurred.

When action of "Delete agent" run, destory is called, it call again "redirect_back".

But @agent is destroyed, redirect_back use "path = agent_path(@agent)" .

So I add for this case.

if message include "deleted", redirect_back is called by destroy.

then redirect_back use "path = agents_path".