### PR TITLE
Fix validation issue of Get url maximum length

### DIFF
--- a/app/helpers/dot_helper.rb
+++ b/app/helpers/dot_helper.rb
@@ -8,7 +8,7 @@ module DotHelper
         } rescue false)
       decorate_svg(svg, agents).html_safe
     else
-      uriquery=URI.encode_www_form(cht: 'gv', chl: agents_dot(agents))
+      uriquery = URI.encode_www_form(cht: 'gv', chl: agents_dot(agents))
       #Get query maximum length should be under 2048 bytes with including "chart?" of google chart request url
       if uriquery.length > 2042
         "Too many agent to display, please check unused agents"

--- a/app/helpers/dot_helper.rb
+++ b/app/helpers/dot_helper.rb
@@ -8,15 +8,15 @@ module DotHelper
         } rescue false)
       decorate_svg(svg, agents).html_safe
     else
-	uriquery=URI.encode_www_form(cht: 'gv', chl: agents_dot(agents))
-	#Get query maximum length should be under 2048 bytes with including "chart?" of google chart request url
-	if uriquery.length > 2042
-		"Too many agent to display, please check unused agents"
-	else
-	      tag('img', src: URI('https://chart.googleapis.com/chart').tap { |uri|
-        	    uri.query = uriquery
-	          })
-	end
+      uriquery=URI.encode_www_form(cht: 'gv', chl: agents_dot(agents))
+      #Get query maximum length should be under 2048 bytes with including "chart?" of google chart request url
+      if uriquery.length > 2042
+        "Too many agent to display, please check unused agents"
+      else
+        tag('img', src: URI('https://chart.googleapis.com/chart').tap { |uri|
+              uri.query = uriquery
+	    })
+      end
     end
   end
 

--- a/app/helpers/dot_helper.rb
+++ b/app/helpers/dot_helper.rb
@@ -8,9 +8,15 @@ module DotHelper
         } rescue false)
       decorate_svg(svg, agents).html_safe
     else
-      tag('img', src: URI('https://chart.googleapis.com/chart').tap { |uri|
-            uri.query = URI.encode_www_form(cht: 'gv', chl: agents_dot(agents))
-          })
+	uriquery=URI.encode_www_form(cht: 'gv', chl: agents_dot(agents))
+	#Get query maximum length should be under 2048 bytes with including "chart?" of google chart request url
+	if uriquery.length > 2042
+		"Too many agent to display, please check unused agents"
+	else
+	      tag('img', src: URI('https://chart.googleapis.com/chart').tap { |uri|
+        	    uri.query = uriquery
+	          })
+	end
     end
   end
 


### PR DESCRIPTION
When agents are generated too many, Get url will be longer. But Get query maximum length should be 2048.
If length is over 2048, google responses error and  Agent Event Flow shows nothing. so I add error message at this case.