### PR TITLE
Update roles to the current recipe names so that 'vagrant up' works out of the box.

### DIFF
--- a/deployment/Cheffile
+++ b/deployment/Cheffile
@@ -3,6 +3,7 @@
 
 site 'http://community.opscode.com/api/v1'
 
+cookbook 'ark'
 cookbook 'runit'
 cookbook 'git', :git => 'git://github.com/opscode-cookbooks/git.git'
 cookbook 'nginx', :git => 'git://github.com/opscode-cookbooks/nginx.git'

--- a/deployment/roles/huginn_development.json
+++ b/deployment/roles/huginn_development.json
@@ -24,7 +24,7 @@
              "recipe[apt]",
              "recipe[mysql::server]",
              "recipe[mysql::client]",
-             "recipe[nodejs::install_from_binary]",
+             "recipe[nodejs::nodejs_from_binary]",
              "recipe[huginn_development]"
            ]
 }

--- a/deployment/roles/huginn_production.json
+++ b/deployment/roles/huginn_production.json
@@ -23,7 +23,7 @@
              "recipe[git]",
              "recipe[apt]",
              "recipe[mysql::server]",
-             "recipe[nodejs::install_from_binary]",
+             "recipe[nodejs::nodejs_from_binary]",
              "recipe[nginx]",
              "recipe[huginn_production]"
            ]


### PR DESCRIPTION

This broke for me on a fresh checkout - I'm a huginn noob but I know what Chef likes.  ;-)

Updating to the current nodejs::recipe name makes things work for this part of the 'vagrant up' process again.