### PR TITLE
Have devise send mail from the ENV['EMAIL_FROM_ADDRESS'] address

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,7 +5,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['EMAIL_FROM_ADDRESS'].presence || 'you@example.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
A simple change to make the password recovery emails work.