### PR TITLE
Do not redfine LiquidDroppable classes

### DIFF
--- a/app/concerns/liquid_droppable.rb
+++ b/app/concerns/liquid_droppable.rb
@@ -21,7 +21,7 @@ module LiquidDroppable
   end
 
   included do
-    const_set :Drop, Kernel.const_set("#{name}Drop", Class.new(Drop))
+    const_set :Drop, Kernel.const_set("#{name}Drop", Class.new(Drop)) unless const_defined?("#{name}Drop")
   end
 
   def to_liquid


### PR DESCRIPTION
This fixes the 'previous definition of xDrop was here' warning when running in the development environment which cache_classes disabled.

Should fix #749