### PR TITLE
Set cache_classes to true in threaded worker

### DIFF
--- a/app/concerns/liquid_droppable.rb
+++ b/app/concerns/liquid_droppable.rb
@@ -21,7 +21,7 @@ module LiquidDroppable
   end
 
   included do
-    const_set :Drop, Kernel.const_set("#{name}Drop", Class.new(Drop)) unless const_defined?("#{name}Drop")
+    const_set :Drop, Kernel.const_set("#{name}Drop", Class.new(Drop))
   end
 
   def to_liquid

--- a/bin/schedule.rb
+++ b/bin/schedule.rb
@@ -11,5 +11,7 @@ unless defined?(Rails)
   exit 1
 end
 
+Rails.application.config.cache_classes = true
+
 scheduler = HuginnScheduler.new(frequency: ENV['SCHEDULER_FREQUENCY'].presence || 0.3)
 scheduler.run!

--- a/bin/threaded.rb
+++ b/bin/threaded.rb
@@ -1,3 +1,4 @@
+Rails.application.config.cache_classes = true
 require 'thread'
 require 'huginn_scheduler'
 


### PR DESCRIPTION
This fixes the 'A copy of TwitterStream has been removed from the module
tree but is still active!' exception when running in development
environment.

There is probably a smarter way to properly unload the TwitterStream class and maybe even support code reloading, but I wasn't able to find it. :smile: