### PR TITLE
allow the webhook agent to loop over returned results if the payload_path points to an array

### DIFF
--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -20,13 +20,14 @@ module Agents
           * `expected_receive_period_in_days` - How often you expect to receive
             events this way. Used to determine if the agent is working.
           * `payload_path` - JSONPath of the attribute in the POST body to be
-            used as the Event payload.
+            used as the Event payload.  If `payload_path` points to an array,
+            Events will be created for each element.
       MD
     end
 
     event_description do
       <<-MD
-        The event payload is base on the value of the `payload_path` option,
+        The event payload is based on the value of the `payload_path` option,
         which is set to `#{interpolated['payload_path']}`.
       MD
     end
@@ -34,7 +35,8 @@ module Agents
     def default_options
       { "secret" => "supersecretstring",
         "expected_receive_period_in_days" => 1,
-        "payload_path" => "payload"}
+        "payload_path" => "some_key"
+      }
     end
 
     def receive_web_request(params, method, format)
@@ -42,7 +44,9 @@ module Agents
       return ["Please use POST requests only", 401] unless method == "post"
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
-      create_event(:payload => payload_for(params))
+      [payload_for(params)].flatten.each do |payload|
+        create_event(payload: payload)
+      end
 
       ['Event Created', 201]
     end

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -3,27 +3,37 @@ require 'spec_helper'
 describe Agents::WebhookAgent do
   let(:agent) do
     _agent = Agents::WebhookAgent.new(:name => 'webhook',
-                                      :options => { 'secret' => 'foobar', 'payload_path' => 'payload' })
+                                      :options => { 'secret' => 'foobar', 'payload_path' => 'some_key' })
     _agent.user = users(:bob)
     _agent.save!
     _agent
   end
-  let(:payload) { {'some' => 'info'} }
+  let(:payload) { {'people' => [{ 'name' => 'bob' }, { 'name' => 'jon' }] } }
 
   describe 'receive_web_request' do
     it 'should create event if secret matches' do
       out = nil
       expect {
-        out = agent.receive_web_request({ 'secret' => 'foobar', 'payload' => payload }, "post", "text/html")
+        out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
       }.to change { Event.count }.by(1)
       expect(out).to eq(['Event Created', 201])
       expect(Event.last.payload).to eq(payload)
     end
 
+    it 'should be able to create multiple events when given an array' do
+      out = nil
+      agent.options['payload_path'] = 'some_key.people'
+      expect {
+        out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      }.to change { Event.count }.by(2)
+      expect(out).to eq(['Event Created', 201])
+      expect(Event.last.payload).to eq({ 'name' => 'jon' })
+    end
+
     it 'should not create event if secrets dont match' do
       out = nil
       expect {
-        out = agent.receive_web_request({ 'secret' => 'bazbat', 'payload' => payload }, "post", "text/html")
+        out = agent.receive_web_request({ 'secret' => 'bazbat', 'some_key' => payload }, "post", "text/html")
       }.to change { Event.count }.by(0)
       expect(out).to eq(['Not Authorized', 401])
     end
@@ -31,7 +41,7 @@ describe Agents::WebhookAgent do
     it "should only accept POSTs" do
       out = nil
       expect {
-        out = agent.receive_web_request({ 'secret' => 'foobar', 'payload' => payload }, "get", "text/html")
+        out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
       }.to change { Event.count }.by(0)
       expect(out).to eq(['Please use POST requests only', 401])
     end


### PR DESCRIPTION
Should fix #764