### PR TITLE
Adding 0.0.0.0 as the interface to bind

### DIFF
--- a/docker/scripts/init
+++ b/docker/scripts/init
@@ -150,7 +150,7 @@ source /app/.env
 
 # Fixup the Procfile and prepare the PORT
 [ -n "\${DO_NOT_RUN_JOBS}" ] && perl -pi -e 's/^jobs:/#jobs:/' /app/Procfile
-perl -pi -e 's/rails server\$/rails server -p \\\$PORT/' /app/Procfile
+perl -pi -e 's/rails server\$/rails server -b 0.0.0.0 -p \\\$PORT/' /app/Procfile
 export PORT
 
 # Start huginn


### PR DESCRIPTION
Adding 0.0.0.0 as the interface to bind, as it seems rails 4.2 changed the default behavior.

I don't code in ruby, so I'm not familliar with ruby tools, so perhaps I didn't do it the right way. Here is my problem and how I solved it:

* I've tried a lot a ways to run the cantino/huginn docker image, but I didn't succeded to connect the web interface, event with the simplest way to call it
* I've entered the running container using "`docker exec -it huginn /bin/bash`" and looked at the processes:
```ps
[...]
huginn      46  0.0  0.0   4440   656 ?        S    10:46   0:00 sh -c /app/vendor/bundle/ruby/2.1.0/gems/foreman-0.63.0/bin/foreman-runner -d '/app' -p -- bundle exec rails server -p $PORT
huginn      47  1.3  1.0 2865768 330568 ?      Sl   10:46   0:18 /usr/bin/ruby2.1 bin/rails server -p 5000
[...]
```
* So it look like the server was `ruby2.1 bin/rails` with extra parameter `-p 5000` to set the port, and that this process was lanched by something called `foreman`
* I also used `netstat -n -p -l`:
```ps
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 127.0.0.1:5000          0.0.0.0:*               LISTEN      -
[...]
```
* So it look like the default behavior of rails is to listen to 127.0.0.1
* google and stackoverflow led me to http://stackoverflow.com/questions/28668436/how-to-change-the-default-binding-ip-of-rails-4-2-development-server
* It look like the behavior changed recently (rails 4.2 seems to be out since december 2014).
* Found the init script with the perl hack to change the launch of rails in what appears to be the foreman config file. Seems like the best place to add `-b 0.0.0.0 ` to listen to every interfaces.
* Due to the nature of containers, I think that letting that interface be configurable would be overkill.

Of course, I tested the change and it finally works, thus this pull requests.