### PR TITLE
Set rufus sleep interval to 0.3 seconds by default

### DIFF
--- a/bin/schedule.rb
+++ b/bin/schedule.rb
@@ -11,5 +11,5 @@ unless defined?(Rails)
   exit 1
 end
 
-scheduler = HuginnScheduler.new(frequency: ENV['SCHEDULER_FREQUENCY'])
+scheduler = HuginnScheduler.new(frequency: ENV['SCHEDULER_FREQUENCY'].presence || 0.3)
 scheduler.run!

--- a/bin/threaded.rb
+++ b/bin/threaded.rb
@@ -33,7 +33,7 @@ end
 
 threads << Thread.new do
   safely do
-    @scheduler = HuginnScheduler.new(frequency: ENV['SCHEDULER_FREQUENCY'])
+    @scheduler = HuginnScheduler.new(frequency: ENV['SCHEDULER_FREQUENCY'].presence || 0.3)
     @scheduler.run!
     puts "Scheduler stopped ..."
   end


### PR DESCRIPTION
Before rufus would use 0.0 as the sleep interval if SCHEDULER_FREQUENCY was not set which caused a significant amout of load due to rufus running in a loop without sleeping at all.

Fixes #795