### PR TITLE
requiring twitter_stream in threaded worker fixes ArgumentError

### DIFF
--- a/bin/threaded.rb
+++ b/bin/threaded.rb
@@ -1,5 +1,6 @@
 require 'thread'
 require 'huginn_scheduler'
+require 'twitter_stream'
 
 STDOUT.sync = true
 STDERR.sync = true


### PR DESCRIPTION
The threaded worker threw 'A copy of TwitterStream has been removed from the module tree but is still active!' when running in development, explicitly requiring 'twitter_stream' fixes that exception.