### PR TITLE
Add file download feature to webhook agent

### DIFF
--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -20,9 +20,9 @@ module Agents
           * `payload_path` - JSONPath of the attribute in the POST body to be
             used as the Event payload.  If `payload_path` points to an array,
             Events will be created for each element.
-          * `action_type` - Mulitiple function selection of Webhook Agent. This version support file download feature.
-          * `form_name` - It's sub option of file download feature. received form name in http request from client side.
-          * `folder_name` - It's sub option of file download feature. download path when action_type is file download.
+          * `filedownload_action` - Need to set true when webhook agent is used for file download. Default value is false.
+          * `form_name` - It's sub option of filedownload_action. received form name in http request from client side.
+          * `folder_name` - It's sub option of filedownload_action. download path when action_type is file download.
       MD
     end
 
@@ -37,7 +37,7 @@ module Agents
       { "secret" => "supersecretstring",
         "expected_receive_period_in_days" => 1,
         "payload_path" => "some_key",
-        "action_type" => "filedownload",
+        "filedownload_action" => "false",
         "form_name" => "webhookform",
         "folder_name" =>"public"}
     end
@@ -95,7 +95,7 @@ module Agents
       return ["Please use POST requests only", 401] unless method == "post"
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
-      if interpolated['action_type'] == "filedownload"
+      if interpolated['filedownload_action'].present? && interpolated['filedownload_action'] == "true"
         file_download_action(params)
       else
         [payload_for(params)].flatten.each do |payload|

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -63,7 +63,7 @@ module Agents
           if interpolated['folder_name'].present?
             tmp_file = "#{Rails.root}/#{interpolated['folder_name']}/#{orgFilename}#{fileid}.#{extension}"
           else
-            tmp_file = "#{Rails.root}/#{orgFilename}#{fileid}.#{extension}"
+            tmp_file = "#{Rails.root}/public/#{orgFilename}#{fileid}.#{extension}"
           end
           fileid += 1
         end

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -20,6 +20,9 @@ module Agents
           * `payload_path` - JSONPath of the attribute in the POST body to be
             used as the Event payload.  If `payload_path` points to an array,
             Events will be created for each element.
+          * `action_type` - Mulitiple function selection of Webhook Agent. This version support file download feature.
+          * `form_name` - It's sub option of file download feature. received form name in http request from client side.
+          * `folder_name` - It's sub option of file download feature. download path when action_type is file download.
       MD
     end
 
@@ -33,8 +36,58 @@ module Agents
     def default_options
       { "secret" => "supersecretstring",
         "expected_receive_period_in_days" => 1,
-        "payload_path" => "some_key"
-      }
+        "payload_path" => "some_key",
+        "action_type" => "filedownload",
+        "form_name" => "webhookform",
+        "folder_name" =>"public"}
+    end
+
+    def file_download_action(params)
+      if params[interpolated['form_name']] != nil
+        uploadflag = params[interpolated['form_name']].is_a?(String)
+        filename = uploadflag  ? params[interpolated['form_name']] : params[interpolated['form_name']].original_filename
+
+        orgFilename = filename.split('.').first
+        extension = filename.split('.').last
+
+        if interpolated['folder_name'].present?
+          dir = Rails.root.join(interpolated['folder_name'])
+          Dir.mkdir(dir) unless File.exists?(dir)
+          tmp_file = "#{Rails.root}/#{interpolated['folder_name']}/#{filename}"
+        else
+          tmp_file = "#{Rails.root}/public/#{filename}"
+        end
+
+        fileid = 0
+        while File.exists?(tmp_file) do
+          if interpolated['folder_name'].present?
+            tmp_file = "#{Rails.root}/#{interpolated['folder_name']}/#{orgFilename}#{fileid}.#{extension}"
+          else
+            tmp_file = "#{Rails.root}/#{orgFilename}#{fileid}.#{extension}"
+          end
+          fileid += 1
+        end
+
+        File.open(tmp_file, 'wb') do |f|
+          if uploadflag
+            f.write  request.body.read
+          else
+            f.write params[interpolated['form_name']].read
+          end
+        end
+
+        senddata = {
+            :fileName => filename,
+            :path => tmp_file
+        }
+      else
+        senddata = {
+            :fileName => "No file",
+            :path => ""
+        }
+      end
+
+      create_event(:payload => senddata)
     end
 
     def receive_web_request(params, method, format)
@@ -42,8 +95,12 @@ module Agents
       return ["Please use POST requests only", 401] unless method == "post"
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
-      [payload_for(params)].flatten.each do |payload|
-        create_event(payload: payload)
+      if interpolated['action_type'] == "filedownload"
+        file_download_action(params)
+      else
+        [payload_for(params)].flatten.each do |payload|
+          create_event(payload: payload)
+        end
       end
 
       ['Event Created', 201]


### PR DESCRIPTION
I wanted to add the feature to send file from client to huginn and this event and received file is used with other agent.
So I added file download feature to webhoook agent with filedownload_action option. This option's default value is false. If value is false, webhook operation is the same as before.