### PR TITLE
Add 'unescapeHTML' functionality to the javascript agent.

### DIFF
--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -21,6 +21,8 @@ module Agents
       * `this.options(key)`
       * `this.log(message)`
       * `this.error(message)`
+      * `this.escapeHtml(htmlToEscape)`
+      * `this.unescapeHtml(htmlToUnescape)`
     MD
 
     def validate_options
@@ -102,7 +104,8 @@ module Agents
           memory.to_json
         end
       end
-      context["unescapeHTML"] = lambda { |a, x| CGI.unescapeHTML(x) }
+      context["escapeHtml"] = lambda { |a, x| CGI.escapeHTML(x) }
+      context["unescapeHtml"] = lambda { |a, x| CGI.unescapeHTML(x) }
 
       context.eval(code)
       context.eval("Agent.#{js_function}();")
@@ -159,8 +162,12 @@ module Agents
           doError(message);
         }
 
-        Agent.unescapeHTML = function(html) {
-          return unescapeHTML(html);
+        Agent.escapeHtml = function(html) {
+          return escapeHtml(html);
+        }
+
+        Agent.unescapeHtml = function(html) {
+          return unescapeHtml(html);
         }
 
         Agent.check = function(){};

--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -102,6 +102,7 @@ module Agents
           memory.to_json
         end
       end
+      context["unescapeHTML"] = lambda { |a, x| CGI.unescapeHTML(x) }
 
       context.eval(code)
       context.eval("Agent.#{js_function}();")
@@ -156,6 +157,10 @@ module Agents
 
         Agent.error = function(message) {
           doError(message);
+        }
+
+        Agent.unescapeHTML = function(html) {
+          return unescapeHTML(html);
         }
 
         Agent.check = function(){};

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -162,9 +162,9 @@ describe Agents::JavaScriptAgent do
       end
     end
 
-    describe "unescaping HTML" do
-      it "can unescape html with this.unescapeHTML in the javascript environment" do
-        @agent.options['code'] = 'Agent.check = function() { this.createEvent({ message: this.unescapeHTML(\'test &quot;escaping&quot; &lt;characters&gt;\'), stuff: { foo: 5 } }); };'
+    describe "escaping and unescaping HTML" do
+      it "can escape and unescape html with this.escapeHtml and this.unescapeHtml in the javascript environment" do
+        @agent.options['code'] = 'Agent.check = function() { this.createEvent({ escaped: this.escapeHtml(\'test \"escaping\" <characters>\'), unescaped: this.unescapeHtml(\'test &quot;unescaping&quot; &lt;characters&gt;\')}); };'
         @agent.save!
         expect {
           expect {
@@ -172,7 +172,7 @@ describe Agents::JavaScriptAgent do
           }.not_to change { AgentLog.count }
         }.to change { Event.count}.by(1)
         created_event = @agent.events.last
-        expect(created_event.payload).to eq({ 'message' => 'test "escaping" <characters>', 'stuff' => { 'foo' => 5 }})
+        expect(created_event.payload).to eq({ 'escaped' => 'test &quot;escaping&quot; &lt;characters&gt;', 'unescaped' => 'test "unescaping" <characters>'})
       end
     end
 

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -162,6 +162,20 @@ describe Agents::JavaScriptAgent do
       end
     end
 
+    describe "unescaping HTML" do
+      it "can unescape html with this.unescapeHTML in the javascript environment" do
+        @agent.options['code'] = 'Agent.check = function() { this.createEvent({ message: this.unescapeHTML(\'test &quot;escaping&quot; &lt;characters&gt;\'), stuff: { foo: 5 } }); };'
+        @agent.save!
+        expect {
+          expect {
+            @agent.check
+          }.not_to change { AgentLog.count }
+        }.to change { Event.count}.by(1)
+        created_event = @agent.events.last
+        expect(created_event.payload).to eq({ 'message' => 'test "escaping" <characters>', 'stuff' => { 'foo' => 5 }})
+      end
+    end
+
     describe "getting incoming events" do
       it "can access incoming events in the JavaScript enviroment via this.incomingEvents" do
         event = Event.new


### PR DESCRIPTION
Just adds a single method to the javascript agent which calls out to CGI.unescapeHTML to convert strings like `'&lt;p&gt;hello world&lt;/p&gt;` to `<p>hello world</p>`