### PR TITLE
Exclude disabled agents from Agent Diagram and add a toggle button

### DIFF
--- a/app/controllers/diagrams_controller.rb
+++ b/app/controllers/diagrams_controller.rb
@@ -1,9 +1,12 @@
 class DiagramsController < ApplicationController
   def show
-    @agents = if params[:scenario_id].present?
-                current_user.scenarios.find(params[:scenario_id]).agents.includes(:receivers)
-              else
-                current_user.agents.includes(:receivers)
-              end
+    if params[:scenario_id].present?
+      @scenario = current_user.scenarios.find(params[:scenario_id])
+      agents = @scenario.agents
+    else
+      agents = current_user.agents
+    end
+    agents = agents.active unless params[:include_disabled].present?
+    @agents = agents.includes(:receivers)
   end
 end

--- a/app/controllers/diagrams_controller.rb
+++ b/app/controllers/diagrams_controller.rb
@@ -6,6 +6,7 @@ class DiagramsController < ApplicationController
     else
       agents = current_user.agents
     end
+    @disabled_agents = agents.inactive
     agents = agents.active unless params[:include_disabled].present?
     @agents = agents.includes(:receivers)
   end

--- a/app/controllers/diagrams_controller.rb
+++ b/app/controllers/diagrams_controller.rb
@@ -7,7 +7,7 @@ class DiagramsController < ApplicationController
       agents = current_user.agents
     end
     @disabled_agents = agents.inactive
-    agents = agents.active unless params[:include_disabled].present?
+    agents = agents.active if params[:exclude_disabled].present?
     @agents = agents.includes(:receivers)
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -60,7 +60,8 @@ class Agent < ActiveRecord::Base
   has_many :scenario_memberships, :dependent => :destroy, :inverse_of => :agent
   has_many :scenarios, :through => :scenario_memberships, :inverse_of => :agents
 
-  scope :active, -> { where(disabled: false) }
+  scope :active,   -> { where(disabled: false) }
+  scope :inactive, -> { where(disabled: true) }
 
   scope :of_type, lambda { |type|
     type = case type

--- a/app/views/diagrams/show.html.erb
+++ b/app/views/diagrams/show.html.erb
@@ -11,10 +11,10 @@
       <div class="btn-group">
         <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, (@scenario ? scenario_path(@scenario) : agents_path), class: "btn btn-default" %>
         <% if (num_disabled = @disabled_agents.count).nonzero? -%>
-          <% if params[:include_disabled] %>
-            <%= link_to @scenario ? scenario_diagram_path(@scenario) : diagram_path, class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-close') %> Hide <%= pluralize(num_disabled, 'disabled Agent') %><% end %>
+          <% if params[:exclude_disabled] %>
+            <%= link_to @scenario ? scenario_diagram_path(@scenario) : diagram_path, class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-open') %> Show <%= pluralize(num_disabled, 'disabled Agent') %><% end %>
           <% else %>
-            <%= link_to @scenario ? scenario_diagram_path(@scenario, include_disabled: true) : diagram_path(include_disabled: true), class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-open') %> Show <%= pluralize(num_disabled, 'disabled Agent') %><% end %>
+            <%= link_to @scenario ? scenario_diagram_path(@scenario, exclude_disabled: true) : diagram_path(exclude_disabled: true), class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-close') %> Hide <%= pluralize(num_disabled, 'disabled Agent') %><% end %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/diagrams/show.html.erb
+++ b/app/views/diagrams/show.html.erb
@@ -10,10 +10,12 @@
       </div>
       <div class="btn-group">
         <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, (@scenario ? scenario_path(@scenario) : agents_path), class: "btn btn-default" %>
-        <% if params[:include_disabled] %>
-          <%= link_to @scenario ? scenario_diagram_path(@scenario) : diagram_path, class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-close') %> Hide <%= pluralize(@disabled_agents.count, 'disabled Agent') %><% end %>
-        <% else %>
-          <%= link_to @scenario ? scenario_diagram_path(@scenario, include_disabled: true) : diagram_path(include_disabled: true), class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-open') %> Show <%= pluralize(@disabled_agents.count, 'disabled Agent') %><% end %>
+        <% if (num_disabled = @disabled_agents.count).nonzero? -%>
+          <% if params[:include_disabled] %>
+            <%= link_to @scenario ? scenario_diagram_path(@scenario) : diagram_path, class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-close') %> Hide <%= pluralize(num_disabled, 'disabled Agent') %><% end %>
+          <% else %>
+            <%= link_to @scenario ? scenario_diagram_path(@scenario, include_disabled: true) : diagram_path(include_disabled: true), class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-open') %> Show <%= pluralize(num_disabled, 'disabled Agent') %><% end %>
+          <% end %>
         <% end %>
       </div>
 

--- a/app/views/diagrams/show.html.erb
+++ b/app/views/diagrams/show.html.erb
@@ -9,7 +9,12 @@
         <h2>Agent Event Flow</h2>
       </div>
       <div class="btn-group">
-        <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, (params[:scenario_id] ? scenario_path(params[:scenario_id]) : agents_path), class: "btn btn-default" %>
+        <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, (@scenario ? scenario_path(@scenario) : agents_path), class: "btn btn-default" %>
+        <% if params[:include_disabled] %>
+          <%= link_to @scenario ? scenario_diagram_path(@scenario) : diagram_path, class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-close') %> Hide disabled Agents<% end %>
+        <% else %>
+          <%= link_to @scenario ? scenario_diagram_path(@scenario, include_disabled: true) : diagram_path(include_disabled: true), class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-open') %> Show disabled Agents<% end %>
+        <% end %>
       </div>
 
       <div class='digraph'>

--- a/app/views/diagrams/show.html.erb
+++ b/app/views/diagrams/show.html.erb
@@ -11,9 +11,9 @@
       <div class="btn-group">
         <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, (@scenario ? scenario_path(@scenario) : agents_path), class: "btn btn-default" %>
         <% if params[:include_disabled] %>
-          <%= link_to @scenario ? scenario_diagram_path(@scenario) : diagram_path, class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-close') %> Hide disabled Agents<% end %>
+          <%= link_to @scenario ? scenario_diagram_path(@scenario) : diagram_path, class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-close') %> Hide <%= pluralize(@disabled_agents.count, 'disabled Agent') %><% end %>
         <% else %>
-          <%= link_to @scenario ? scenario_diagram_path(@scenario, include_disabled: true) : diagram_path(include_disabled: true), class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-open') %> Show disabled Agents<% end %>
+          <%= link_to @scenario ? scenario_diagram_path(@scenario, include_disabled: true) : diagram_path(include_disabled: true), class: 'btn btn-default' do %><%= icon_tag('glyphicon-eye-open') %> Show <%= pluralize(@disabled_agents.count, 'disabled Agent') %><% end %>
         <% end %>
       </div>
 


### PR DESCRIPTION
I think it's a good idea to keep an agent for later reference or cloning even after it has served its purpose, so I usually just disable agents rather than deleting them.  However, a growing number of disabled agents get in the way of getting a whole picture of what is actually/actively being done by Huginn.

So, what about making it optional to draw disabled agents in an Agent diagram?