### PR TITLE
Make RssAgent emit events for new feed items in chronological order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Changes
 
+* Jun 17, 2015   - RssAgent emits events for new feed items in chronological order.
 * Jun 15, 2015   - Liquid filter `uri_expand` added.
 * Jun 12, 2015   - RSSAgent can now accept an array of URLs.
 * Jun 8, 2015    - WebsiteAgent includes a `use_namespaces` option to enable XML namespaces.

--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -77,7 +77,7 @@ module Agents
           feed = FeedNormalizer::FeedNormalizer.parse(response.body)
           feed.clean! if interpolated['clean'] == 'true'
           created_event_count = 0
-          feed.entries.each do |entry|
+          feed.entries.sort_by { |entry| [entry.date_published, entry.last_updated] }.each do |entry|
             entry_id = get_entry_id(entry)
             if check_and_track(entry_id)
               created_event_count += 1

--- a/spec/models/agents/rss_agent_spec.rb
+++ b/spec/models/agents/rss_agent_spec.rb
@@ -59,9 +59,11 @@ describe Agents::RssAgent do
         agent.check
       }.to change { agent.events.count }.by(20)
 
-      event = agent.events.last
-      expect(event.payload['url']).to eq("https://github.com/cantino/huginn/commit/d0a844662846cf3c83b94c637c1803f03db5a5b0")
-      expect(event.payload['urls']).to eq(["https://github.com/cantino/huginn/commit/d0a844662846cf3c83b94c637c1803f03db5a5b0"])
+      first, *, last = agent.events.last(20)
+      expect(first.payload['url']).to eq("https://github.com/cantino/huginn/commit/d0a844662846cf3c83b94c637c1803f03db5a5b0")
+      expect(first.payload['urls']).to eq(["https://github.com/cantino/huginn/commit/d0a844662846cf3c83b94c637c1803f03db5a5b0"])
+      expect(last.payload['url']).to eq("https://github.com/cantino/huginn/commit/d465158f77dcd9078697e6167b50abbfdfa8b1af")
+      expect(last.payload['urls']).to eq(["https://github.com/cantino/huginn/commit/d465158f77dcd9078697e6167b50abbfdfa8b1af"])
     end
 
     it "should track ids and not re-emit the same item when seen again" do


### PR DESCRIPTION
RssAgent now sorts feed items by the date published and then by the last
updated time when creating events.

Previously it would create an event for each new feed item in order of
appearance, but when most feeds list items in reverse chronological
order you would often end up seeing newer items processed earlier than
older items.