### PR TITLE
Add a url_on_receive option to WebsiteAgent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Changes
 
+* Jun 19, 2015   - Add `url_from_event` to WebsiteAgent.
 * Jun 17, 2015   - RssAgent emits events for new feed items in chronological order.
 * Jun 15, 2015   - Liquid filter `uri_expand` added.
 * Jun 12, 2015   - RSSAgent can now accept an array of URLs.

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -19,7 +19,7 @@ module Agents
 
       `url` can be a single url, or an array of urls (for example, for multiple pages with the exact same structure but different content to scrape)
 
-      The WebsiteAgent can also scrape based on incoming events. It will scrape the url contained in the `url` key of the incoming event payload, or if you set `url_on_receive` it is used as a Liquid template to generate the url to access. If you specify `merge` as the `mode`, it will retain the old payload and update it with the new values.
+      The WebsiteAgent can also scrape based on incoming events. It will scrape the url contained in the `url` key of the incoming event payload, or if you set `url_from_event` it is used as a Liquid template to generate the url to access. If you specify `merge` as the `mode`, it will retain the old payload and update it with the new values.
 
       # Supported Document Types
 
@@ -135,7 +135,7 @@ module Agents
 
     def validate_options
       # Check for required fields
-      errors.add(:base, "either url or url_on_receive is required") unless options['url'].present? || options['url_on_receive'].present?
+      errors.add(:base, "either url or url_from_event is required") unless options['url'].present? || options['url_from_event'].present?
       errors.add(:base, "expected_update_period_in_days is required") unless options['expected_update_period_in_days'].present?
       if !options['extract'].present? && extraction_type != "json"
         errors.add(:base, "extract is required for all types except json")
@@ -259,7 +259,7 @@ module Agents
       incoming_events.each do |event|
         interpolate_with(event) do
           url_to_scrape =
-            if url_template = options['url_on_receive'].presence
+            if url_template = options['url_from_event'].presence
               interpolate_string(url_template)
             else
               event.payload['url']

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -633,6 +633,17 @@ fire: hot
         }.to change { Event.count }.by(1)
       end
 
+      it "should use url_on_receive as url to scrape if it exists when receiving an event" do
+        stub = stub_request(:any, 'http://example.org/?url=http%3A%2F%2Fxkcd.com')
+
+        @checker.options = @valid_options.merge(
+          'url_on_receive' => 'http://example.org/?url={{url | uri_escape}}'
+        )
+        @checker.receive([@event])
+
+        expect(stub).to have_been_requested
+      end
+
       it "should interpolate values from incoming event payload" do
         expect {
           @valid_options['extract'] = {

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -633,11 +633,11 @@ fire: hot
         }.to change { Event.count }.by(1)
       end
 
-      it "should use url_on_receive as url to scrape if it exists when receiving an event" do
+      it "should use url_from_event as url to scrape if it exists when receiving an event" do
         stub = stub_request(:any, 'http://example.org/?url=http%3A%2F%2Fxkcd.com')
 
         @checker.options = @valid_options.merge(
-          'url_on_receive' => 'http://example.org/?url={{url | uri_escape}}'
+          'url_from_event' => 'http://example.org/?url={{url | uri_escape}}'
         )
         @checker.receive([@event])
 


### PR DESCRIPTION
This option allows a WebsiteAgent to build a URL using Liquid templating from an incoming event.

Currently the URL to scrape when a WebAgent receives an event is fixed to its `url` value, and it is not very handy you have to create an EventFormattingAgent just for composing a URL.

For instance, you can create a WebAgent that receives events from an RssAgent to fetch a full text content using the Readability API with the following option settings:

```json
{
  "expected_update_period_in_days": "2",
  "url_on_receive": "{% capture token %}{% credential readability_api_key %}{% endcapture %}https://readability.com/api/content/v1/parser?url={{url | uri_escape}}&max_pages=1&token={{token | uri_escape}}",
  "type": "json",
  "mode": "merge",
  "extract": {
    "content": {
      "path": "content"
    }
  }
}
```
(Assuming you have `readability_api_key` in Credentials)