### PR TITLE
Allow integer indexes as strings when doing regexp extraction

### DIFF
--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -231,7 +231,7 @@ module Agents
               when Integer
                 # ok
               when String
-                if re && !re.names.include?(index)
+                if index.to_i.to_s != index && re && !re.names.include?(index)
                   errors.add(:base, "no named capture #{index.inspect} found in regexp for #{name.inspect})")
                 end
               when nil
@@ -429,7 +429,11 @@ module Agents
         regexp = Regexp.new(extraction_details['regexp'])
         result = []
         doc.scan(regexp) {
-          result << Regexp.last_match[extraction_details['index']]
+          index_or_named_group = extraction_details['index']
+          if index_or_named_group.is_a?(String) && index_or_named_group.to_i.to_s == index_or_named_group
+            index_or_named_group = index_or_named_group.to_i
+          end
+          result << Regexp.last_match[index_or_named_group]
         }
         log "Extracting #{extraction_type} at #{regexp}: #{result}"
         result

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -105,6 +105,8 @@ describe LiquidInterpolatable::Filters do
         to_return(status: 301, headers: { Location: 'http://tinyurl.com.x/cccc' })
       stub_request(:head, 'http://tinyurl.com.x/cccc').
         to_return(status: 301, headers: { Location: 'http://www.example.com/welcome' })
+      stub_request(:head, 'http://www.example.com/welcome').
+        to_return(status: 200)
 
       (1..5).each do |i|
         stub_request(:head, "http://2many.x/#{i}").

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -577,7 +577,7 @@ fire: hot
             'mode' => 'on_change',
             'extract' => {
               'word' => { 'regexp' => '^(.+?): (.+)$', index: 1 },
-              'property' => { 'regexp' => '^(.+?): (.+)$', index: 2 },
+              'property' => { 'regexp' => '^(.+?): (.+)$', index: '2' },
             }
           }
           @checker = Agents::WebsiteAgent.new(name: 'Text Site', options: site)
@@ -585,7 +585,7 @@ fire: hot
           @checker.save!
         end
 
-        it "works with regexp" do
+        it "works with regexp with named capture" do
           @checker.options = @checker.options.merge('extract' => {
             'word' => { 'regexp' => '^(?<word>.+?): (?<property>.+)$', index: 'word' },
             'property' => { 'regexp' => '^(?<word>.+?): (?<property>.+)$', index: 'property' },
@@ -602,7 +602,7 @@ fire: hot
           expect(event2.payload['property']).to eq('hot')
         end
 
-        it "works with regexp with named capture" do
+        it "works with regexp" do
           expect {
             @checker.check
           }.to change { Event.count }.by(2)


### PR DESCRIPTION
Should fix #673.