### PR TITLE
Add Liquid regex replace filters

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -190,7 +190,15 @@ module LiquidInterpolatable
         'concat(' << subs.join(', ') << ')'
       end
     end
-
+    
+    def regex_replace(input, regex, replacement = ''.freeze)
+      input.to_s.gsub(Regexp.new(regex), replacement.to_s)
+    end
+    
+    def regex_replace_first(input, regex, replacement = ''.freeze)
+      input.to_s.sub(Regexp.new(regex), replacement.to_s)
+    end
+    
     private
 
     def logger

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -166,16 +166,21 @@ describe LiquidInterpolatable::Filters do
       end
     end
     
-    describe 'regex_replace' do
-      it 'should replace all occurences of a string using regex' do
-        expect(@filter.regex_replace('foobar foobar', /\S+bar/, 'foobaz')).to eq('foobaz foobaz')
-      end
-    end
+    describe 'regex replace' do
+      let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
 
-    describe 'regex_replace_first' do
-      it 'should replace the first occurences of a string using regex' do
-        expect(@filter.regex_replace_first('foobar foobar', /\S+bar/, 'foobaz')).to eq('foobaz foobar')
+      it 'should replace the first occurrence of a string using regex' do
+        agent.interpolation_context['something'] = 'foobar foobar'
+        agent.options['cleaned'] = '{{ something | regex_replace_first: "\S+bar", "foobaz"  }}'
+        expect(agent.interpolated['cleaned']).to eq('foobaz foobar')
       end
+
+      it 'should replace the all occurrences of a string using regex' do
+        agent.interpolation_context['something'] = 'foobar foobar'
+        agent.options['cleaned'] = '{{ something | regex_replace: "\S+bar", "foobaz"  }}'
+        expect(agent.interpolated['cleaned']).to eq('foobaz foobaz') 
+      end
+    
     end
     
   end

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -165,5 +165,18 @@ describe LiquidInterpolatable::Filters do
         expect(@agent.interpolated['long_url']).to eq('http://2many.x/6')
       end
     end
+    
+    describe 'regex_replace' do
+      it 'should replace all occurences of a string using regex' do
+        expect(@filter.regex_replace('foobar foobar', /\S+bar/, 'foobaz')).to eq('foobaz foobaz')
+      end
+    end
+
+    describe 'regex_replace_first' do
+      it 'should replace the first occurences of a string using regex' do
+        expect(@filter.regex_replace_first('foobar foobar', /\S+bar/, 'foobaz')).to eq('foobaz foobar')
+      end
+    end
+    
   end
 end


### PR DESCRIPTION
Copied and tweaked the general idea from [here](https://github.com/Shopify/liquid/issues/202#issuecomment-19112872). Essentially using the same code that [Liquid uses](https://github.com/Shopify/liquid/blob/master/lib/liquid/standardfilters.rb#L185) for their `replace` filter.

This should resolve #859 and #885