### PR TITLE
Fix regex_replace

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -201,15 +201,15 @@ module LiquidInterpolatable
         'concat(' << subs.join(', ') << ')'
       end
     end
-    
+
     def regex_replace(input, regex, replacement = ''.freeze)
       input.to_s.gsub(Regexp.new(regex), replacement.to_s)
     end
-    
+
     def regex_replace_first(input, regex, replacement = ''.freeze)
       input.to_s.sub(Regexp.new(regex), replacement.to_s)
     end
-    
+
     private
 
     def logger

--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -236,6 +236,32 @@ module LiquidInterpolatable
       "v" => "\v",
     }
 
+    # Unescape a replacement text for use in the second argument of
+    # gsub/sub.  The following escape sequences are recognized:
+    #
+    # - "\\" (backslash itself)
+    # - "\a" (alert)
+    # - "\b" (backspace)
+    # - "\e" (escape)
+    # - "\f" (form feed)
+    # - "\n" (new line)
+    # - "\r" (carriage return)
+    # - "\s" (space)
+    # - "\t" (horizontal tab)
+    # - "\u{XXXX}" (unicode codepoint)
+    # - "\v" (vertical tab)
+    # - "\xXX" (hexadecimal character)
+    # - "\1".."\9" (numbered capture groups)
+    # - "\+" (last capture group)
+    # - "\k<name>" (named capture group)
+    # - "\&" or "\0" (complete matched text)
+    # - "\`" (string before match)
+    # - "\'" (string after match)
+    #
+    # Octal escape sequences are deliberately unsupported to avoid
+    # conflict with numbered capture groups.  Rather obscure Emacs
+    # style character codes ("\C-x", "\M-\C-x" etc.) are also omitted
+    # from this implementation.
     def unescape_replacement(s)
       s.gsub(/\\(?:([\d+&`'\\]|k<\w+>)|u\{([[:xdigit:]]+)\}|x([[:xdigit:]]{2})|(.))/) {
         if c = $1

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -1,0 +1,8 @@
+module Liquid
+  # https://github.com/Shopify/liquid/pull/623
+  remove_const :PartialTemplateParser
+  remove_const :TemplateParser
+
+  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}(?:(?:[^'"{}]+|#{QuotedString})*?|.*?)#{VariableIncompleteEnd}/m
+  TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/m
+end

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -187,6 +187,12 @@ describe LiquidInterpolatable::Filters do
       agent.options['cleaned'] = '{{ something | regex_replace_first: "\S+bar", "foobaz"  }}'
       expect(agent.interpolated['cleaned']).to eq('foobaz foobar')
     end
+
+    it 'should support escaped characters' do
+      agent.interpolation_context['something'] = "foo\\1\n\nfoo\\bar\n\nfoo\\baz"
+      agent.options['test'] = "{{ something | regex_replace_first: '\\\\(\\w{2,})', '\\1\\\\' | regex_replace_first: '\\n+', '\\n'  }}"
+      expect(agent.interpolated['test']).to eq("foo\\1\nfoobar\\\n\nfoo\\baz")
+    end
   end
 
   describe 'regex_replace' do
@@ -196,6 +202,12 @@ describe LiquidInterpolatable::Filters do
       agent.interpolation_context['something'] = 'foobar foobar'
       agent.options['cleaned'] = '{{ something | regex_replace: "\S+bar", "foobaz"  }}'
       expect(agent.interpolated['cleaned']).to eq('foobaz foobaz')
+    end
+
+    it 'should support escaped characters' do
+      agent.interpolation_context['something'] = "foo\\1\n\nfoo\\bar\n\nfoo\\baz"
+      agent.options['test'] = "{{ something | regex_replace: '\\\\(\\w{2,})', '\\1\\\\' | regex_replace: '\\n+', '\\n'  }}"
+      expect(agent.interpolated['test']).to eq("foo\\1\nfoobar\\\nfoobaz\\")
     end
   end
 end

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -177,23 +177,25 @@ describe LiquidInterpolatable::Filters do
         expect(@agent.interpolated['long_url']).to eq('http://2many.x/6')
       end
     end
-    
-    describe 'regex replace' do
-      let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
+  end
 
-      it 'should replace the first occurrence of a string using regex' do
-        agent.interpolation_context['something'] = 'foobar foobar'
-        agent.options['cleaned'] = '{{ something | regex_replace_first: "\S+bar", "foobaz"  }}'
-        expect(agent.interpolated['cleaned']).to eq('foobaz foobar')
-      end
+  describe 'regex_replace_first' do
+    let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
 
-      it 'should replace the all occurrences of a string using regex' do
-        agent.interpolation_context['something'] = 'foobar foobar'
-        agent.options['cleaned'] = '{{ something | regex_replace: "\S+bar", "foobaz"  }}'
-        expect(agent.interpolated['cleaned']).to eq('foobaz foobaz') 
-      end
-    
+    it 'should replace the first occurrence of a string using regex' do
+      agent.interpolation_context['something'] = 'foobar foobar'
+      agent.options['cleaned'] = '{{ something | regex_replace_first: "\S+bar", "foobaz"  }}'
+      expect(agent.interpolated['cleaned']).to eq('foobaz foobar')
     end
-    
+  end
+
+  describe 'regex_replace' do
+    let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
+
+    it 'should replace the all occurrences of a string using regex' do
+      agent.interpolation_context['something'] = 'foobar foobar'
+      agent.options['cleaned'] = '{{ something | regex_replace: "\S+bar", "foobaz"  }}'
+      expect(agent.interpolated['cleaned']).to eq('foobaz foobaz')
+    end
   end
 end


### PR DESCRIPTION
As discussed in #886, there are a couple of flaws in Liquid for the regex_replace/regex_replace_first filters to work as most users would expect.

- Use of the closing curly brace in string literals causes SyntaxError: Fix by monkey-patching Liquid
- No escaped characters supported in string literals: Fix by specially handling the replacement parameter of regex_replace/regex_replace_first
