### PR TITLE
stub spec that was making real HTTP call

### DIFF
--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -349,6 +349,10 @@ describe AgentsController do
   end
 
   describe "POST dry_run" do
+    before do
+      stub_request(:any, /xkcd/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
+    end
+
     it "does not actually create any agent, event or log" do
       sign_in users(:bob)
       expect {

--- a/spec/support/vcr_support.rb
+++ b/spec/support/vcr_support.rb
@@ -2,7 +2,7 @@ require 'vcr'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
-  c.allow_http_connections_when_no_cassette = true
+  c.allow_http_connections_when_no_cassette = false
   c.hook_into :webmock
   c.default_cassette_options = { record: :new_episodes}
   c.configure_rspec_metadata!


### PR DESCRIPTION
Should fix #883.  @dsander, it seems like `c.allow_http_connections_when_no_cassette = false` is what I was looking for.