### PR TITLE
Ruby gem agents (WIP)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,3 +146,6 @@ on_heroku do
   gem 'unicorn'
   gem 'rails_12factor', group: :production
 end
+
+gem 'huginn_agent', git: 'git@github.com:darrencauthon/huginn_agent.git'
+gem 'proof_of_concept_huginn_agents', git: 'git@github.com:darrencauthon/proof_of_concept_huginn_agents.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,19 @@ GIT
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
 
+GIT
+  remote: git@github.com:darrencauthon/huginn_agent.git
+  revision: 021fb14918aede94df37f08d189e4c447fb79d49
+  specs:
+    huginn_agent (0.0.1)
+      activesupport
+
+GIT
+  remote: git@github.com:darrencauthon/proof_of_concept_huginn_agents.git
+  revision: c5b6560467714bf0e8a74667efc61d0ed0a7c9eb
+  specs:
+    proof_of_concept_huginn_agents (0.0.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -523,6 +536,7 @@ DEPENDENCIES
   haversine
   hipchat (~> 1.2.0)
   httparty (~> 0.13)
+  huginn_agent!
   hypdf (~> 1.0.7)
   jquery-rails (~> 3.1.3)
   json (~> 1.8.1)
@@ -543,6 +557,7 @@ DEPENDENCIES
   omniauth-twitter
   omniauth-wunderlist!
   pg
+  proof_of_concept_huginn_agents!
   protected_attributes (~> 1.0.8)
   pry-rails
   quiet_assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,14 +30,14 @@ GIT
 
 GIT
   remote: git@github.com:darrencauthon/huginn_agent.git
-  revision: 021fb14918aede94df37f08d189e4c447fb79d49
+  revision: 9b9906019b7ab76fbe7c493097f79eb903274439
   specs:
     huginn_agent (0.0.1)
       activesupport
 
 GIT
   remote: git@github.com:darrencauthon/proof_of_concept_huginn_agents.git
-  revision: c5b6560467714bf0e8a74667efc61d0ed0a7c9eb
+  revision: fd672d52766230fb2ba137fb64c747fea25c4460
   specs:
     proof_of_concept_huginn_agents (0.0.1)
 

--- a/config/initializers/hacking_stuff.rb
+++ b/config/initializers/hacking_stuff.rb
@@ -1,0 +1,5 @@
+require 'huginn_agent'
+
+HuginnAgent.hack_huginn_to_accept_me
+
+HuginnAgent.types.each { |t| t.emit }


### PR DESCRIPTION
This is a PR meant for discussion -- DO NOT MERGE.  I find it easier to discuss ideas when there's some semblance of a working copy.  That's all this is.

So I really like Huginn, and it comes with a TON of features.  But it's not really extendable in the sense that new modules can be created independently of the main app and then linked in (like, say, a Ruby gem that has a new agent).  Huginn is a Rails app, and you run it as a Rails app, and if you want to extend it you dump more code in your Rails app.  And if someone else wants that new agent you wrote... they copy-paste that code in their Huginn instance.

Since Huginn comes with so much, part of me thinks that I should try to live and operate in the features that Huginn provides.  But the fun side of me says, "Find a way to make modular Huginn agents!"  So I did.

This is nowhere near done, but it's hit a stage where I've been able to create a stand-alone gem with two Huginn agents and get them added to Huginn.  

Is this a good idea?  Am I nuts?  I'm open to any feedback!  But if this is something that the Huginn community thinks is a good idea, then I'd like to mold this to conform with the project.  But if you all think it's not a good idea... I'm probably going to do it anyway, on my own, because **I** like it.  :smile:

So here's how it works:

### Add a reference to huginn_agent

This is a small Ruby gem that provides one class:  ```HuginnAgent```.  

```HuginnAgent``` is meant to serve as the base class for other agents, just like ```Agent```.

### Create a new agent

Here is a sample agent, inheriting from ```HuginnAgent```.  It would be very similar to ```Agent```, except for one thing:  It's a plain ol' Ruby object, with no dependencies against Rails or ActiveRecord.

The code for this base class is here:  https://github.com/darrencauthon/huginn_agent/blob/021fb14918aede94df37f08d189e4c447fb79d49/lib/huginn_agent.rb

```ruby
module ProofOfConceptHuginnAgents
  class Happy < HuginnAgent
    def self.description
      "# I'm Happy"
    end
  end
end
```

### Plug your gems into your Huginn app

I've been doing this with an initializer, like so:

```ruby
require 'huginn_agent'

HuginnAgent.hack_huginn_to_accept_me

HuginnAgent.types.each { |t| t.emit }
```

This initializer does two things:

1)  It monkey-patches over a couple things in Huginn.  Huginn is hardcoded to look for agents in a specific spot, so I jump into a few methods to tell Huginn know they could be somewhere else.

2)  It loops through all of the declared ```HuginnAgent``` classes, and "emits" them to an ActiveRecord object.  

So that's the trick... this plain ol' Ruby object will map itself to the existing ```Agent``` format.  A little nutty, but it works.

### Screenshots

So I only mapped the ```description``` method, but so far so good:

My sample gem (https://github.com/darrencauthon/proof_of_concept_huginn_agents/tree/c5b6560467714bf0e8a74667efc61d0ed0a7c9eb/lib/proof_of_concept_huginn_agents) has two agents, ```Happy``` and ```Sad```.  The agents get sucked into the list of agents.

![huginn](https://cloud.githubusercontent.com/assets/148768/8725685/409fe8e8-2b9b-11e5-86c6-29ce9fe7b014.png)

![huginn](https://cloud.githubusercontent.com/assets/148768/8725703/559d0988-2b9b-11e5-8cfd-b45717a05fbe.png)


### Why?

Modular code is cool.  And I love the idea of getting a new agent by adding a reference to a gem.  