### PR TITLE
Remove keep-awake ping on heroku

### DIFF
--- a/deployment/heroku/unicorn.rb
+++ b/deployment/heroku/unicorn.rb
@@ -17,11 +17,6 @@ Thread.new do
 
     sleep 45
 
-    if ENV['DOMAIN']
-      force_ssl = ENV['FORCE_SSL'] == 'true'
-      Net::HTTP.get_response(URI((force_ssl ? "https://" : "http://") + ENV['DOMAIN']))
-    end
-
     begin
       Process.getpgid worker_pid
     rescue Errno::ESRCH


### PR DESCRIPTION
Heroku's new Free tier requires applications to sleep for at least six hours a day, thus we can not keep huginn awake.
Every paid tier does not but the application to sleep at all.

#893 