### PR TITLE
Do not try to display service_label when service has been deleted

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,6 +80,7 @@ module ApplicationHelper
   end
 
   def service_label(service)
+    return if service.nil?
     content_tag :span, [
       omniauth_provider_icon(service.provider),
       service_label_text(service)


### PR DESCRIPTION
Fixes an exception in AgentController#show when the service of an oauthable agent has been deleted.