### PR TITLE
Use FaradayMiddleware::Gzip in faraday_middleware 0.10.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'twitter-stream', github: 'cantino/twitter-stream', branch: 'huginn'
 gem 'omniauth-twitter'
 
 # Tumblr Agents
-gem 'tumblr_client'
+gem 'tumblr_client', github: 'knu/tumblr_client', branch: 'patch-1'
 gem 'omniauth-tumblr'
 
 # Dropbox Agents
@@ -64,7 +64,7 @@ gem 'devise', '~> 3.4.0'
 gem 'dotenv-rails', '~> 2.0.1'
 gem 'em-http-request', '~> 1.1.2'
 gem 'faraday', '~> 0.9.0'
-gem 'faraday_middleware'
+gem 'faraday_middleware', '>= 0.10.0'
 gem 'feed-normalizer'
 gem 'font-awesome-sass', '~> 4.3.2'
 gem 'foreman', '~> 0.63.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,19 @@ GIT
       rest-client (~> 1.8)
 
 GIT
+  remote: git://github.com/knu/tumblr_client.git
+  revision: d6f1f64a7cba381345c588e28ebcff28048c3a6c
+  branch: patch-1
+  specs:
+    tumblr_client (0.8.5)
+      faraday (~> 0.9.0)
+      faraday_middleware (~> 0.9)
+      json
+      mime-types
+      oauth
+      simple_oauth
+
+GIT
   remote: git://github.com/wunderlist/omniauth-wunderlist.git
   revision: d0910d0396107b9302aa1bc50e74bb140990ccb8
   ref: d0910d0396107b9302aa1bc50e74bb140990ccb8
@@ -153,7 +166,7 @@ GEM
     extlib (0.9.16)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
+    faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     feed-normalizer (1.5.2)
       hpricot (>= 0.6)
@@ -437,13 +450,6 @@ GEM
     tins (1.3.2)
     treetop (1.5.3)
       polyglot (~> 0.3)
-    tumblr_client (0.8.4)
-      faraday (~> 0.9.0)
-      faraday_middleware (~> 0.9.0)
-      json
-      mime-types
-      oauth
-      simple_oauth
     twilio-ruby (3.11.6)
       builder (>= 2.1.2)
       jwt (>= 0.1.2)
@@ -508,7 +514,7 @@ DEPENDENCIES
   dropbox-api
   em-http-request (~> 1.1.2)
   faraday (~> 0.9.0)
-  faraday_middleware
+  faraday_middleware (>= 0.10.0)
   feed-normalizer
   ffi (>= 1.9.4)
   font-awesome-sass (~> 4.3.2)
@@ -566,7 +572,7 @@ DEPENDENCIES
   spring-commands-rspec
   string-scrub
   therubyracer (~> 0.12.2)
-  tumblr_client
+  tumblr_client!
   twilio-ruby (~> 3.11.5)
   twitter (~> 5.14.0)
   twitter-stream!

--- a/app/concerns/web_request_concern.rb
+++ b/app/concerns/web_request_concern.rb
@@ -59,6 +59,8 @@ module WebRequestConcern
         builder.request :basic_auth, *userinfo
       end
 
+      builder.use FaradayMiddleware::Gzip
+
       case backend = faraday_backend
         when :typhoeus
           require 'typhoeus/adapters/faraday'


### PR DESCRIPTION
This should eliminate the need for user to specify the "unzip" option (introduced by #766) when a gzip'd content is returned through Accept/Content-Encoding negotiation.

tumblr_agent currently refuses to work with faraday_middleware 0.10.0, which version requirement must be relaxed. (tumblr/tumblr_client#48)