### PR TITLE
RssAgent: Use RSS::Parser directly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ gem 'dotenv-rails', '~> 2.0.1'
 gem 'em-http-request', '~> 1.1.2'
 gem 'faraday', '~> 0.9.0'
 gem 'faraday_middleware'
-gem 'feed-normalizer'
 gem 'font-awesome-sass', '~> 4.3.2'
 gem 'foreman', '~> 0.63.0'
 # geokit-rails doesn't work with geokit 1.8.X but it specifies ~> 1.5


### PR DESCRIPTION
FeedNormalizer is no longer maintained, and its Atom support has flaws
in that it throws away what RSS::Parser returns and falls back to using
SimpleRSS which is not capable of handling XML entities, resulting in
getting ususable URLs such as ones including `&amp;`.

A breaking change is removal of the `clean` option which needs to be
reimplemented if it is important, while I personally think you should
use EventFormattingAgent to tweak feed contents if you need to.

This should address #889 and #955, among others.