### PR TITLE
Escape invalid urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ gem 'string-scrub'	# for ruby <2.1
 gem 'therubyracer', '~> 0.12.2'
 gem 'typhoeus', '~> 0.6.3'
 gem 'uglifier', '>= 1.3.0'
+gem 'addressable', '>= 2.3.8'
 
 group :development do
   gem 'better_errors', '~> 1.1'

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -1,6 +1,7 @@
 require 'nokogiri'
 require 'date'
 require 'uri'
+require 'addressable/uri'
 
 module Agents
   class WebsiteAgent < Agent
@@ -261,7 +262,12 @@ module Agents
     end
 
     def get_valid_url(url)
-      return (url =~ URI::ABS_URI) ? url : URI.escape(url)
+      if (url =~ URI::ABS_URI) 
+      	return url
+      end
+
+      parsed = Addressable::URI.parse(url)      
+      return parsed.normalize.to_s
     end
 
     def check_url(url, payload = {})

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -1,5 +1,6 @@
 require 'nokogiri'
 require 'date'
+require 'uri'
 
 module Agents
   class WebsiteAgent < Agent
@@ -259,13 +260,19 @@ module Agents
       end
     end
 
+    def get_valid_url(url)
+      return (url =~ URI::ABS_URI) ? url : URI.escape(url)
+    end
+
     def check_url(url, payload = {})
       unless /\Ahttps?:\/\//i === url
         error "Ignoring a non-HTTP url: #{url.inspect}"
         return
       end
-      log "Fetching #{url}"
-      response = faraday.get(url)
+
+      valid_url = get_valid_url(url)
+      log "Fetching #{valid_url}"
+      response = faraday.get(valid_url)
       raise "Failed: #{response.inspect}" unless response.success?
 
       interpolation_context.stack {
@@ -303,7 +310,7 @@ module Agents
           interpolated['extract'].keys.each do |name|
             result[name] = output[name][index]
             if name.to_s == 'url'
-              result[name] = (response.env[:url] + result[name]).to_s
+              result[name] = (response.env[:url] + get_valid_url(result[name])).to_s
             end
           end
 

--- a/spec/data_fixtures/urlTest.html
+++ b/spec/data_fixtures/urlTest.html
@@ -6,10 +6,10 @@
     <body>
         <ul>
             <li><a href="http://google.com">google</a></li>
-            <li><a href="https://www.google.ca/search?q=some%20query">broken</a></li>
+            <li><a href="https://www.google.ca/search?q=some query">broken</a></li>
             <li><a href="https://www.google.ca/search?q=some%20query">escaped</a></li>
-            <li><a href="http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8">unicode url</a></li>
-            <li><a href="https://www.google.ca/search?q=%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8">unicode param</a></li>
+            <li><a href="http://ko.wikipedia.org/wiki/위키백과:대문">unicode url</a></li>
+            <li><a href="https://www.google.ca/search?q=위키백과:대문">unicode param</a></li>
             <li><a href="http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8">percent encoded url</a></li>
             <li><a href="https://www.google.ca/search?q=%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8">percent encoded param</a></li>
         </ul>

--- a/spec/data_fixtures/urlTest.html
+++ b/spec/data_fixtures/urlTest.html
@@ -1,0 +1,17 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <title>test</title>
+    </head>
+    <body>
+        <ul>
+            <li><a href="http://google.com">google</a></li>
+            <li><a href="https://www.google.ca/search?q=some%20query">broken</a></li>
+            <li><a href="https://www.google.ca/search?q=some%20query">escaped</a></li>
+            <li><a href="http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8">unicode url</a></li>
+            <li><a href="https://www.google.ca/search?q=%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8">unicode param</a></li>
+            <li><a href="http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8">percent encoded url</a></li>
+            <li><a href="https://www.google.ca/search?q=%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8">percent encoded param</a></li>
+        </ul>
+    </body>
+</html>

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -752,4 +752,69 @@ fire: hot
       end
     end
   end
+
+  describe "checking urls" do
+    before do
+      stub_request(:any, /example/).
+        to_return(:body => File.read(Rails.root.join("spec/data_fixtures/urlTest.html")), :status => 200)
+      @valid_options = {
+        'name' => "Url Test",
+        'expected_update_period_in_days' => "2",
+        'type' => "html",
+        'url' => "http://www.example.com",
+        'mode' => 'all',
+        'extract' => {
+          'url' => { 'css' => "a", 'value' => "@href" },
+        }
+      }
+      @checker = Agents::WebsiteAgent.new(:name => "ua", :options => @valid_options)
+      @checker.user = users(:bob)
+      @checker.save!
+    end
+
+    describe "#check" do
+      it "should check hostname" do
+        @checker.check
+        event = Event.all[2]
+        expect(event.payload['url']).to eq("http://google.com")
+      end
+
+      it "should check unescaped query" do
+        @checker.check
+        event = Event.all[3]
+        expect(event.payload['url']).to eq("https://www.google.ca/search?q=some%20query")
+      end
+
+      it "should check properly escaped query" do
+        @checker.check
+        event = Event.all[4]
+        expect(event.payload['url']).to eq("https://www.google.ca/search?q=some%20query")
+      end
+
+      it "should check unescaped unicode url" do
+        @checker.check
+        event = Event.all[5]
+        expect(event.payload['url']).to eq("http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8")
+      end
+
+      it "should check unescaped unicode query" do
+        @checker.check
+        event = Event.all[6]
+        expect(event.payload['url']).to eq("https://www.google.ca/search?q=%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8")
+      end
+
+      it "should check properly escaped unicode url" do
+        @checker.check
+        event = Event.all[7]
+        expect(event.payload['url']).to eq("http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8")
+      end
+
+      it "should check properly escaped unicode query" do
+        @checker.check
+        event = Event.all[8]
+        expect(event.payload['url']).to eq("https://www.google.ca/search?q=%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8")
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
addresses urls with unescaped unicode characters and spaces (Issue #938)