### PR TITLE
Adds the ability to allow public signup without invite code (retry)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ FORCE_SSL=false
 # You can see its use in user.rb.  PLEASE CHANGE THIS!
 INVITATION_CODE=try-huginn
 
-# If you don't want to require users to have an invitation code, set this to true
+# If you don't want to require new users to have an invitation code in order to sign up, set this to true.
 SKIP_INVITATION_CODE=false
 
 #############################

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,9 @@ FORCE_SSL=false
 # You can see its use in user.rb.  PLEASE CHANGE THIS!
 INVITATION_CODE=try-huginn
 
+# If you don't want to require users to have an invitation code, set this to true
+SKIP_INVITATION_CODE=false
+
 #############################
 #    Email Configuration    #
 #############################

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ActiveRecord::Base
   validates_presence_of :username
   validates_uniqueness_of :username
   validates_format_of :username, :with => /\A[a-zA-Z0-9_-]{3,15}\Z/, :message => "can only contain letters, numbers, underscores, and dashes, and must be between 3 and 15 characters in length."
-  validates_inclusion_of :invitation_code, :on => :create, :in => INVITATION_CODES, :message => "is not valid"
+  validates_inclusion_of :invitation_code, :on => :create, :in => INVITATION_CODES, :message => "is not valid", if: ->{ User.using_invitation_code? }
 
   has_many :user_credentials, :dependent => :destroy, :inverse_of => :user
   has_many :events, -> { order("events.created_at desc") }, :dependent => :delete_all, :inverse_of => :user
@@ -39,5 +39,9 @@ class User < ActiveRecord::Base
     else
       where(conditions).first
     end
+  end
+
+  def self.using_invitation_code?
+    ENV['SKIP_INVITATION_CODE'] != 'true'
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -30,13 +30,15 @@ bin/setup_heroku
           </div>
           <% end %>
 
-          <div class="form-group">
-            <%= f.label :invitation_code, class: 'col-md-4 control-label' %>
-            <div class="col-md-6">
-              <%= f.text_field :invitation_code, class: 'form-control' %>
-              <span class="help-inline">We are not yet open to the public.  If you have an invitation code, please enter it here.</span>
+          <% if User.using_invitation_code? %>
+            <div class="form-group">
+              <%= f.label :invitation_code, class: 'col-md-4 control-label' %>
+              <div class="col-md-6">
+                <%= f.text_field :invitation_code, class: 'form-control' %>
+                <span class="help-inline">We are not yet open to the public.  If you have an invitation code, please enter it here.</span>
+              </div>
             </div>
-          </div>
+          <% end %>
 
           <div class="form-group">
             <%= f.label :email, class: 'col-md-4 control-label' %>

--- a/db/migrate/20150808115436_remove_requirement_from_users_invitation_code.rb
+++ b/db/migrate/20150808115436_remove_requirement_from_users_invitation_code.rb
@@ -1,0 +1,5 @@
+class RemoveRequirementFromUsersInvitationCode < ActiveRecord::Migration
+  def change
+    change_column_null :users, :invitation_code, true, ENV['INVITATION_CODE']
+  end
+end

--- a/db/migrate/20150808115436_remove_requirement_from_users_invitation_code.rb
+++ b/db/migrate/20150808115436_remove_requirement_from_users_invitation_code.rb
@@ -1,5 +1,5 @@
 class RemoveRequirementFromUsersInvitationCode < ActiveRecord::Migration
   def change
-    change_column_null :users, :invitation_code, true, ENV['INVITATION_CODE']
+    change_column_null :users, :invitation_code, true, ENV['INVITATION_CODE'].presence || 'try-huginn'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150507153436) do
+ActiveRecord::Schema.define(version: 20150808115436) do
 
   create_table "agent_logs", force: :cascade do |t|
     t.integer  "agent_id",          limit: 4,                 null: false
@@ -176,7 +176,7 @@ ActiveRecord::Schema.define(version: 20150507153436) do
     t.string   "unlock_token",           limit: 255
     t.datetime "locked_at"
     t.string   "username",               limit: 191,                 null: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
-    t.string   "invitation_code",        limit: 255,                 null: false,                     collation: "utf8_bin"
+    t.string   "invitation_code",        limit: 255,                                                  collation: "utf8_bin"
     t.integer  "scenario_count",         limit: 4,   default: 0,     null: false
   end
 

--- a/deployment/site-cookbooks/huginn_production/files/default/env.example
+++ b/deployment/site-cookbooks/huginn_production/files/default/env.example
@@ -39,6 +39,9 @@ FORCE_SSL=false
 # You can see its use in user.rb.  PLEASE CHANGE THIS!
 INVITATION_CODE=try-huginn
 
+# If you don't want to require users to have an invitation code, set this to true
+SKIP_INVITATION_CODE=false
+
 #############################
 #    Email Configuration    #
 #############################

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -14,6 +14,13 @@ describe User do
           is_expected.not_to allow_value(v).for(:invitation_code)
         end
       end
+
+      it "skips this validation if configured to do so" do
+        stub(User).using_invitation_code? {false}
+        %w['foo', 'bar', nil, ''].each do |v|
+          is_expected.to allow_value(v).for(:invitation_code)
+        end
+      end
     end
   end
 end

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -3,22 +3,33 @@ require 'spec_helper'
 describe User do
   describe "validations" do
     describe "invitation_code" do
-      it "only accepts valid invitation codes" do
-        User::INVITATION_CODES.each do |v|
-          is_expected.to allow_value(v).for(:invitation_code)
+      context "when configured to use invitation codes" do
+        before do
+          stub(User).using_invitation_code? {true}
+        end
+        
+        it "only accepts valid invitation codes" do
+          User::INVITATION_CODES.each do |v|
+            is_expected.to allow_value(v).for(:invitation_code)
+          end
+        end
+  
+        it "can reject invalid invitation codes" do
+          %w['foo', 'bar'].each do |v|
+            is_expected.not_to allow_value(v).for(:invitation_code)
+          end
         end
       end
-
-      it "can reject invalid invitation codes" do
-        %w['foo', 'bar'].each do |v|
-          is_expected.not_to allow_value(v).for(:invitation_code)
+      
+      context "when configured not to use invitation codes" do
+        before do
+          stub(User).using_invitation_code? {false}
         end
-      end
-
-      it "skips this validation if configured to do so" do
-        stub(User).using_invitation_code? {false}
-        %w['foo', 'bar', nil, ''].each do |v|
-          is_expected.to allow_value(v).for(:invitation_code)
+        
+        it "skips this validation" do
+          %w['foo', 'bar', nil, ''].each do |v|
+            is_expected.to allow_value(v).for(:invitation_code)
+          end
         end
       end
     end


### PR DESCRIPTION
- Introduces new ENV variable SKIP_INVITATION_CODE, intentionally
      phrased in the negative so that the absence of the variable
      will not change the behavior of existing deployments.
- Useful if deploying a hosted version of Huginn where you want people to be able to sign up without 
      an invitation code. 