### PR TITLE
Intercept email in development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,7 @@ INVITATION_CODE=try-huginn
 # Outgoing email settings.  To use Gmail or Google Apps, put your Google Apps domain or gmail.com
 # as the SMTP_DOMAIN and your Gmail username and password as the SMTP_USER_NAME and SMTP_PASSWORD.
 #
-# PLEASE NOTE: In order to enable emails locally (e.g., when not in the production Rails environment),
+# PLEASE NOTE: In order to enable sending real emails via SMTP locally (e.g., when not in the production Rails environment),
 # you must also set SEND_EMAIL_IN_DEVELOPMENT to true below.
 #
 # If you have trouble with port 587 on Gmail, you can also try setting
@@ -68,7 +68,8 @@ SMTP_PORT=587
 SMTP_AUTHENTICATION=plain
 SMTP_ENABLE_STARTTLS_AUTO=true
 
-# Send emails when running in the development Rails environment.
+# Set to true to send real emails via SMTP when running in the development Rails environment.
+# Set to false to have emails intercepted in development and displayed at http://localhost:3000/letter_opener
 SEND_EMAIL_IN_DEVELOPMENT=false
 
 # The address from which system emails will appear to be sent.

--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ group :development do
   gem 'guard'
   gem 'guard-livereload'
   gem 'guard-rspec'
+  gem 'letter_opener_web'
 
   group :test do
     gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,12 @@ GEM
     kramdown (1.3.3)
     launchy (2.4.2)
       addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
+    letter_opener_web (1.3.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     libv8 (3.16.14.7)
     liquid (3.0.6)
     listen (2.7.9)
@@ -529,6 +535,7 @@ DEPENDENCIES
   jsonpath (~> 0.5.6)
   kaminari (~> 0.16.1)
   kramdown (~> 1.3.3)
+  letter_opener_web
   liquid (~> 3.0.3)
   mini_magick
   mqtt

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ If you just want to play around, you can simply fork this repository, then perfo
 * Read the [wiki][wiki] for usage examples and to get started making new Agents.
 * Periodically run `git fetch upstream` and then `git checkout master && git merge upstream/master` to merge in the newest version of Huginn.
 
-Note: by default, emails are not sent in the `development` Rails environment, which is what you just setup.  If you'd like to enable emails when playing with Huginn locally, set `SEND_EMAIL_IN_DEVELOPMENT` to `true` in your `.env` file.
+Note: By default, emails are intercepted in the `development` Rails environment, which is what you just setup.  You can view 
+them at [http://localhost:3000/letter_opener](http://localhost:3000/letter_opener). If you'd like to send real emails via SMTP when playing 
+with Huginn locally, set `SEND_EMAIL_IN_DEVELOPMENT` to `true` in your `.env` file.
 
 If you need more detailed instructions, see the [Novice setup guide][novice-setup-guide].
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,8 +39,11 @@ Huginn::Application.configure do
 
   config.action_mailer.default_url_options = { :host => ENV['DOMAIN'] }
   config.action_mailer.asset_host = ENV['DOMAIN']
-  config.action_mailer.perform_deliveries = ENV['SEND_EMAIL_IN_DEVELOPMENT'] == 'true'
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
+  if ENV['SEND_EMAIL_IN_DEVELOPMENT'] == 'true'
+    config.action_mailer.delivery_method = :smtp
+  else
+    config.action_mailer.delivery_method = :letter_opener
+  end
   # smtp_settings moved to config/initializers/action_mailer.rb
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,7 @@ Huginn::Application.configure do
   if ENV['SEND_EMAIL_IN_DEVELOPMENT'] == 'true'
     config.action_mailer.delivery_method = :smtp
   else
-    config.action_mailer.delivery_method = :letter_opener
+    config.action_mailer.delivery_method = :letter_opener_web
   end
   # smtp_settings moved to config/initializers/action_mailer.rb
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,10 @@ Huginn::Application.routes.draw do
   devise_for :users,
              controllers: { omniauth_callbacks: 'omniauth_callbacks' },
              sign_out_via: [:post, :delete]
+  
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 
   get "/about" => "home#about"
   root :to => "home#index"

--- a/deployment/site-cookbooks/huginn_production/files/default/env.example
+++ b/deployment/site-cookbooks/huginn_production/files/default/env.example
@@ -46,7 +46,7 @@ INVITATION_CODE=try-huginn
 # Outgoing email settings.  To use Gmail or Google Apps, put your Google Apps domain or gmail.com
 # as the SMTP_DOMAIN and your Gmail username and password as the SMTP_USER_NAME and SMTP_PASSWORD.
 # 
-# PLEASE NOTE: In order to enable emails locally (e.g., when not in the production Rails environment),
+# PLEASE NOTE: In order to enable sending real emails via SMTP locally (e.g., when not in the production Rails environment),
 # you must also set SEND_EMAIL_IN_DEVELOPMENT to true below.
 
 SMTP_DOMAIN=your-domain-here.com
@@ -57,7 +57,8 @@ SMTP_PORT=587
 SMTP_AUTHENTICATION=plain
 SMTP_ENABLE_STARTTLS_AUTO=true
 
-# Send emails when running in the development Rails environment.
+# Set to true to send real emails via SMTP when running in the development Rails environment.
+# Set to false to have emails intercepted in development and displayed at http://localhost:3000/letter_opener
 SEND_EMAIL_IN_DEVELOPMENT=false
 
 # The address from which system emails will appear to be sent.


### PR DESCRIPTION
- Actually "sends" out email without need to configure an SMTP host locally
- Lets you use all kinds of email addresses, not just real ones
- Prevents you from spamming yourself and others while developing