### PR TITLE
local email was not configured correctly without this change

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -2,15 +2,5 @@
 
 smtp_config = YAML::load(ERB.new(File.read(Rails.root.join('config', 'smtp.yml'))).result)
 if smtp_config.keys.include? Rails.env
-  Huginn::Application.config.action_mailer.smtp_settings = smtp_config[Rails.env].symbolize_keys
+  ActionMailer::Base.smtp_settings = smtp_config[Rails.env].symbolize_keys
 end
-
-# Huginn::Application.config.action_mailer.smtp_settings = {
-#   address: ENV['SMTP_SERVER'] || 'smtp.gmail.com',
-#   port: ENV['SMTP_PORT'] || 587,
-#   domain: ENV['SMTP_DOMAIN'],
-#   authentication: ENV['SMTP_AUTHENTICATION'] || 'plain',
-#   enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false,
-#   user_name: ENV['SMTP_USER_NAME'],
-#   password: ENV['SMTP_PASSWORD']
-# }


### PR DESCRIPTION
I was testing out @TildeWill's PR and ran into an issue where I couldn't get any email to be sent from development until I made this change.  It looks much like [these symptoms](http://stackoverflow.com/questions/11334990/what-is-the-difference-between-config-action-mailer-smtp-settings-and-actionmail), but I can't find a gem that would be messing with it.  Any ideas?