### PR TITLE
Include development group in docker build and switch default port

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN /scripts/setup
 
 VOLUME /var/lib/mysql
 
-EXPOSE 5000
+EXPOSE 3000
 
 CMD ["/scripts/init"]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,7 +47,7 @@ The CMD launches Huginn via the scripts/init script. This may become the ENTRYPO
 
 Simple stand-alone usage:
 
-    docker run -it -p 5000:5000 cantino/huginn
+    docker run -it -p 3000:3000 cantino/huginn
 
 To link to another mysql container, for example:
 
@@ -57,7 +57,7 @@ To link to another mysql container, for example:
         -e HUGINN_MYSQL_PASSWORD=somethingsecret \
         -e HUGINN_MYSQL_ROOT_PASSWORD=somethingevenmoresecret \
         cantino/huginn
-    docker run --rm --name huginn --link newcentury_mysql:MYSQL -p 5000:5000 \
+    docker run --rm --name huginn --link newcentury_mysql:MYSQL -p 3000:3000 \
         -e HUGINN_DATABASE_NAME=huginn \
         -e HUGINN_DATABASE_USER=huginn \
         -e HUGINN_DATABASE_PASSWORD=somethingsecret \
@@ -65,7 +65,7 @@ To link to another mysql container, for example:
 
 To link to another container named 'postgres':
 
-    docker run --rm --name huginn --link POSTGRES:mysql -p 5000:5000 -e "DATABASE_USER=huginn" -e "DATABASE_PASSWORD=pass@word" cantino/huginn
+    docker run --rm --name huginn --link POSTGRES:mysql -p 3000:3000 -e "DATABASE_USER=huginn" -e "DATABASE_PASSWORD=pass@word" cantino/huginn
 
 ## Environment Variables
 

--- a/docker/scripts/setup
+++ b/docker/scripts/setup
@@ -29,7 +29,7 @@ if [ -d "/scripts/cache" ]; then
   mv /scripts/cache vendor/
   chown -R huginn:huginn vendor/cache
 fi
-sudo -u huginn -H bundle install --deployment --without development test
+sudo -u huginn -H bundle install --deployment --without test
 
 # silence setlocale message (THANKS DEBIAN!)
 cat > /etc/default/locale <<EOF


### PR DESCRIPTION
This fixes #981 and supersedes #982 

It also changes the exposed port to 3000 to make the image work on kitematic again.

@ianblenke Sorry this messes up #905, I wanted to make sure we have a working image as soon as possible.