### PR TITLE
Webhook verbs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,3 +609,6 @@ DEPENDENCIES
   weibo_2!
   wunderground (~> 1.2.0)
   xmpp4r (~> 0.5.6)
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,6 +609,3 @@ DEPENDENCIES
   weibo_2!
   wunderground (~> 1.2.0)
   xmpp4r (~> 0.5.6)
-
-BUNDLED WITH
-   1.10.6

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -40,7 +40,7 @@ module Agents
     def receive_web_request(params, method, format)
       secret = params.delete('secret')
       verbs = (options['verbs'] ? options['verbs'] : 'post').split(';')
-      return ["Please use #{verbs.first.upcase} requests only", 401] unless verbs.include?(method)
+      return ["Please use #{verbs.join('/').upcase} requests only", 401] unless verbs.include?(method)
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
       [payload_for(params)].flatten.each do |payload|

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -46,7 +46,7 @@ module Agents
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
       #check the verbs
-      verbs = (options['verbs'] || 'post').split(/[,;]/).map { |x| x.strip.downcase }
+      verbs = (interpolated['verbs'] || 'post').split(/[,;]/).map { |x| x.strip.downcase }
       return ["Please use #{verbs.join('/').upcase} requests only", 401] unless verbs.include?(method)
 
       [payload_for(params)].flatten.each do |payload|

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -20,6 +20,9 @@ module Agents
         * `payload_path` - JSONPath of the attribute in the POST body to be
           used as the Event payload.  If `payload_path` points to an array,
           Events will be created for each element.
+        * `verbs` - Comma-separated list of http verbs your agent will accept.
+          For example, "post;get" will enable POST and GET requests. Defaults
+          to "post".
       MD
     end
 

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -39,7 +39,7 @@ module Agents
 
     def receive_web_request(params, method, format)
       secret = params.delete('secret')
-      return ["Please use POST requests only", 401] unless method == "post"
+      return ["Please use POST requests only", 401] unless method == "post" || options['verbs']
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
       [payload_for(params)].flatten.each do |payload|

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -46,7 +46,7 @@ module Agents
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
       #check the verbs
-      verbs = (options['verbs'] ? options['verbs'] : 'post').split(/[,;]/).map { |x| x.strip.downcase }
+      verbs = (options['verbs'] || 'post').split(/[,;]/).map { |x| x.strip.downcase }
       return ["Please use #{verbs.join('/').upcase} requests only", 401] unless verbs.include?(method)
 
       [payload_for(params)].flatten.each do |payload|

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -21,7 +21,7 @@ module Agents
           used as the Event payload.  If `payload_path` points to an array,
           Events will be created for each element.
         * `verbs` - Comma-separated list of http verbs your agent will accept.
-          For example, "post;get" will enable POST and GET requests. Defaults
+          For example, "post,get" will enable POST and GET requests. Defaults
           to "post".
       MD
     end
@@ -46,7 +46,7 @@ module Agents
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
       #check the verbs
-      verbs = (interpolated['verbs'] || 'post').split(/[,;]/).map { |x| x.strip.downcase }
+      verbs = (interpolated['verbs'] || 'post').split(/,/).map { |x| x.strip.downcase }
       return ["Please use #{verbs.join('/').upcase} requests only", 401] unless verbs.include?(method)
 
       [payload_for(params)].flatten.each do |payload|

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -39,7 +39,8 @@ module Agents
 
     def receive_web_request(params, method, format)
       secret = params.delete('secret')
-      return ["Please use POST requests only", 401] unless method == "post" || options['verbs']
+      verbs = (options['verbs'] ? options['verbs'] : 'post').split(';')
+      return ["Please use #{verbs.first.upcase} requests only", 401] unless verbs.include?(method)
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
       [payload_for(params)].flatten.each do |payload|

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -46,7 +46,7 @@ module Agents
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 
       #check the verbs
-      verbs = (interpolated['verbs'] || 'post').split(/,/).map { |x| x.strip.downcase }
+      verbs = (interpolated['verbs'] || 'post').split(/,/).map { |x| x.strip.downcase }.select { |x| x.present? }
       return ["Please use #{verbs.join('/').upcase} requests only", 401] unless verbs.include?(method)
 
       [payload_for(params)].flatten.each do |payload|

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -39,7 +39,7 @@ module Agents
 
     def receive_web_request(params, method, format)
       secret = params.delete('secret')
-      verbs = (options['verbs'] ? options['verbs'] : 'post').split(';')
+      verbs = (options['verbs'] ? options['verbs'] : 'post').split(/[,;]/).map { |x| x.strip.downcase }
       return ["Please use #{verbs.join('/').upcase} requests only", 401] unless verbs.include?(method)
       return ["Not Authorized", 401] unless secret == interpolated['secret']
 

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -38,10 +38,13 @@ module Agents
     end
 
     def receive_web_request(params, method, format)
+      # check the secret
       secret = params.delete('secret')
+      return ["Not Authorized", 401] unless secret == interpolated['secret']
+
+      #check the verbs
       verbs = (options['verbs'] ? options['verbs'] : 'post').split(/[,;]/).map { |x| x.strip.downcase }
       return ["Please use #{verbs.join('/').upcase} requests only", 401] unless verbs.include?(method)
-      return ["Not Authorized", 401] unless secret == interpolated['secret']
 
       [payload_for(params)].flatten.each do |payload|
         create_event(payload: payload)

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -164,6 +164,36 @@ describe Agents::WebhookAgent do
 
       end
 
+      context "flaky content with commas" do
+
+        before { agent.options['verbs'] = ';;  PUT,POST; gEt , ;' }
+
+        it "should accept PUT" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+        it "should accept GET" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+        it "should accept POST" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+      end
+
     end
 
   end

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -192,6 +192,14 @@ describe Agents::WebhookAgent do
           expect(out).to eq(['Event Created', 201])
         end
 
+        it "should not accept DELETE" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "delete", "text/html")
+          }.to change { Event.count }.by(0)
+          expect(out).to eq(['Please use PUT/POST/GET requests only', 401])
+        end
+
       end
 
     end

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -80,6 +80,14 @@ describe Agents::WebhookAgent do
           expect(out).to eq(['Event Created', 201])
         end
 
+        it "should not accept PUT" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+          }.to change { Event.count }.by(0)
+          expect(out).to eq(['Please use GET/POST requests only', 401])
+        end
+
       end
 
       context "accepting only get" do

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -82,6 +82,80 @@ describe Agents::WebhookAgent do
 
       end
 
+      context "accepting only get" do
+
+        before { agent.options['verbs'] = 'get' }
+
+        it "should accept GET" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+        it "should not accept POST" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+          }.to change { Event.count }.by(0)
+          expect(out).to eq(['Please use GET requests only', 401])
+        end
+
+      end
+
+      context "accepting only post" do
+
+        before { agent.options['verbs'] = 'post' }
+
+        it "should not accept GET" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+          }.to change { Event.count }.by(0)
+          expect(out).to eq(['Please use POST requests only', 401])
+        end
+
+        it "should accept POST" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+      end
+
+      context "accepting only put" do
+
+        before { agent.options['verbs'] = 'put' }
+
+        it "should accept PUT" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+        it "should not accept GET" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+          }.to change { Event.count }.by(0)
+          expect(out).to eq(['Please use PUT requests only', 401])
+        end
+
+        it "should not accept POST" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+          }.to change { Event.count }.by(0)
+          expect(out).to eq(['Please use PUT requests only', 401])
+        end
+
+      end
+
     end
 
   end

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -62,7 +62,7 @@ describe Agents::WebhookAgent do
 
       context "accepting get and post" do
 
-        before { agent.options['verbs'] = 'get;post' }
+        before { agent.options['verbs'] = 'get,post' }
 
         it "should accept GET" do
           out = nil
@@ -166,7 +166,7 @@ describe Agents::WebhookAgent do
 
       context "flaky content with commas" do
 
-        before { agent.options['verbs'] = ';;  PUT,POST; gEt , ;' }
+        before { agent.options['verbs'] = ',,  PUT,POST, gEt , ,' }
 
         it "should accept PUT" do
           out = nil

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -60,6 +60,28 @@ describe Agents::WebhookAgent do
 
       end
 
+      context "accepting get and post" do
+
+        before { agent.options['verbs'] = 'get;post' }
+
+        it "should accept GET" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+        it "should accept POST" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+      end
+
     end
 
   end

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -38,12 +38,29 @@ describe Agents::WebhookAgent do
       expect(out).to eq(['Not Authorized', 401])
     end
 
-    it "should only accept POSTs" do
-      out = nil
-      expect {
-        out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
-      }.to change { Event.count }.by(0)
-      expect(out).to eq(['Please use POST requests only', 401])
+    describe "receiving events" do
+
+      context "default settings" do
+
+        it "should not accept GET" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+          }.to change { Event.count }.by(0)
+          expect(out).to eq(['Please use POST requests only', 401])
+        end
+
+        it "should accept POST" do
+          out = nil
+          expect {
+            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+          }.to change { Event.count }.by(1)
+          expect(out).to eq(['Event Created', 201])
+        end
+
+      end
+
     end
+
   end
 end


### PR DESCRIPTION
This PR will open support for other HTTP verbs on the webhook agent.  Suggested this on #935 a while ago.  

I'm doing this because I'd like to integrate Huginn with Workflow on iOs... which only supports GET requests at the moment.

It defaults to the existing behavior, so existing users should not notice any change.

![huginn](https://cloud.githubusercontent.com/assets/148768/9578062/904b3ef8-4fac-11e5-9ca9-e7de01d2d897.png)

![mozilla_firefox](https://cloud.githubusercontent.com/assets/148768/9578089/c8a1254c-4fac-11e5-8ec0-0717547d6454.png)

![huginn](https://cloud.githubusercontent.com/assets/148768/9578135/234f80d8-4fad-11e5-8708-fe0c3d74d901.png)
