### PR TITLE
Enable `strict: false` in database.yml

### DIFF
--- a/app/models/agent_log.rb
+++ b/app/models/agent_log.rb
@@ -35,7 +35,7 @@ class AgentLog < ActiveRecord::Base
   protected
 
   def scrub_message
-    if message_changed?
+    if message_changed? && !message.nil?
       self.message = message.inspect unless message.is_a?(String)
       self.message.scrub!{ |bytes| "<#{bytes.unpack('H*')[0]}>" }
     end

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,6 +9,7 @@ development:
   host: <%= ENV['DATABASE_HOST'] || "" %>
   port: <%= ENV['DATABASE_PORT'] || "" %>
   socket: <%= ENV['DATABASE_SOCKET'] || ["/var/run/mysqld/mysqld.sock", "/opt/local/var/run/mysql5/mysqld.sock", "/tmp/mysql.sock"].find { |path| File.exist? path } %>
+  strict: false
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -23,6 +24,7 @@ test:
   password:  <%= ENV['DATABASE_PASSWORD'].presence || "" %>
   socket: <%= ENV['DATABASE_SOCKET'] || ["/var/run/mysqld/mysqld.sock", "/opt/local/var/run/mysql5/mysqld.sock", "/tmp/mysql.sock"].find { |path| File.exist? path } %>
   port: <%= ENV['DATABASE_PORT'] || "" %>
+  strict: false
 
 production:
   adapter: <%= ENV['DATABASE_ADAPTER'].presence || "mysql2" %>
@@ -35,3 +37,4 @@ production:
   host: <%= ENV['DATABASE_HOST'] || "" %>
   port: <%= ENV['DATABASE_PORT'] || "" %>
   socket: <%= ENV['DATABASE_SOCKET'] || ["/var/run/mysqld/mysqld.sock", "/opt/local/var/run/mysql5/mysqld.sock", "/tmp/mysql.sock"].find{ |path| File.exist? path } %>
+  strict: false


### PR DESCRIPTION
Rails 4 defaulted this on, making MySQL complain on bad encoding.  I'm not a huge fan of making the DB less strict, but I think it may ease some things.