### PR TITLE
Integration of explicitly setting the SMTP SSL verification mode. (.env.example)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,9 @@ SEND_EMAIL_IN_DEVELOPMENT=false
 # The address from which system emails will appear to be sent.
 EMAIL_FROM_ADDRESS=from_address@gmail.com
 
+# Explicitly set the SMTP OpenSSL verification mode to "none", "peer", "client_once" or "fail_if_no_peer_cert" instead of using the default setting.
+SMTP_OPENSSL_VERIFY_MODE=
+
 ###########################
 #      Agent Logging      #
 ###########################


### PR DESCRIPTION
Integration of explicitly setting the SMTP SSL verification mode.