### PR TITLE
Add SSL verification options to smtp.yml

### DIFF
--- a/config/smtp.yml
+++ b/config/smtp.yml
@@ -6,6 +6,9 @@ development:
   enable_starttls_auto: <%= ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false %>
   user_name: <%= ENV['SMTP_USER_NAME'] || "" %>
   password: <%= ENV['SMTP_PASSWORD'] || "" %>
+  openssl_verify_mode: <%= ENV['SMTP_OPENSSL_VERIFY_MODE'].presence || 'null' %>
+  ca_path: <%= ENV['SMTP_OPENSSL_CA_PATH'].presence || 'null' %>
+  ca_file: <%= ENV['SMTP_OPENSSL_CA_FILE'].presence || 'null' %>
 
 staging:
   address: <%= ENV['SMTP_SERVER'] || "smtp.gmail.com" %>
@@ -15,6 +18,9 @@ staging:
   enable_starttls_auto: <%= ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false %>
   user_name: <%= ENV['SMTP_USER_NAME'] || "" %>
   password: <%= ENV['SMTP_PASSWORD'] || "" %>
+  openssl_verify_mode: <%= ENV['SMTP_OPENSSL_VERIFY_MODE'].presence || 'null' %>
+  ca_path: <%= ENV['SMTP_OPENSSL_CA_PATH'].presence || 'null' %>
+  ca_file: <%= ENV['SMTP_OPENSSL_CA_FILE'].presence || 'null' %>
 
 production:
   address: <%= ENV['SMTP_SERVER'] || "smtp.gmail.com" %>
@@ -24,3 +30,6 @@ production:
   enable_starttls_auto: <%= ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false %>
   user_name: <%= ENV['SMTP_USER_NAME'] || "" %>
   password: <%= ENV['SMTP_PASSWORD'] || "" %>
+  openssl_verify_mode: <%= ENV['SMTP_OPENSSL_VERIFY_MODE'].presence || 'null' %>
+  ca_path: <%= ENV['SMTP_OPENSSL_CA_PATH'].presence || 'null' %>
+  ca_file: <%= ENV['SMTP_OPENSSL_CA_FILE'].presence || 'null' %>


### PR DESCRIPTION
Based on the [source of the Mail gem](https://github.com/mikel/mail/blob/0f9393bb3ef1344aa76d6dac28db3a4934c65087/lib/mail/network/delivery_methods/smtp.rb), I think the defaults should be `null` (`nil` in YAML).

The best security would be to use `peer` and to provide a valid ca path.  (Update via `curl http://curl.haxx.se/ca/cacert.pem -o /usr/local/etc/openssl/cert.pem` perhaps?)  But I don't know if we should set that as a default.  Thoughts?

This should fix #1024 and replace #1026 and #1027.