### PR TITLE
Handle truncated payloads

### DIFF
--- a/lib/json_with_indifferent_access.rb
+++ b/lib/json_with_indifferent_access.rb
@@ -1,6 +1,9 @@
 class JSONWithIndifferentAccess
   def self.load(json)
     ActiveSupport::HashWithIndifferentAccess.new(JSON.parse(json || '{}'))
+  rescue JSON::ParserError
+    Rails.logger.error "Unparsable JSON in JSONWithIndifferentAccess: #{json}"
+    { 'error' => 'unparsable json detected during de-serialization' }
   end
 
   def self.dump(hash)


### PR DESCRIPTION
When payloads get truncated in the DB due to encoding issues, at least do not blow up on reading them.

The underlying issue is that I'm on an old version of MySQL that doesn't support utf8mb4_unicode_ci, so sometimes odd emoji break a row and an event gets corrupted.  Clearly the right solution is for me to upgrade, but we also probably shouldn't raise when reading a corrupt Event.