### PR TITLE
Enable attachments in the Slack agent (#1047)

### DIFF
--- a/app/models/agents/slack_agent.rb
+++ b/app/models/agents/slack_agent.rb
@@ -81,7 +81,7 @@ module Agents
             slack_opts[:icon_url] = opts[:icon]
           end
         end
-        slack_notifier.ping opts[:message], slack_opts
+        slack_notifier.ping opts[:message], slack_opts.stringify_keys
       end
     end
   end

--- a/app/models/agents/slack_agent.rb
+++ b/app/models/agents/slack_agent.rb
@@ -74,10 +74,12 @@ module Agents
       incoming_events.each do |event|
         opts = interpolated(event)
         slack_opts = filter_options(opts)
-        if /^:/.match(opts[:icon])
-          slack_opts[:icon_emoji] = opts[:icon]
-        else
-          slack_opts[:icon_url] = opts[:icon]
+        if opts[:icon].to_s != ''
+          if /^:/.match(opts[:icon])
+            slack_opts[:icon_emoji] = opts[:icon]
+          else
+            slack_opts[:icon_url] = opts[:icon]
+          end
         end
         slack_notifier.ping opts[:message], slack_opts
       end

--- a/app/models/agents/slack_agent.rb
+++ b/app/models/agents/slack_agent.rb
@@ -1,6 +1,7 @@
 module Agents
   class SlackAgent < Agent
     DEFAULT_USERNAME = 'Huginn'
+    ALLOWED_PARAMS = ['channel', 'username', 'unfurl_links', 'attachments']
 
     cannot_be_scheduled!
     cannot_create_events!
@@ -65,14 +66,20 @@ module Agents
       @slack_notifier ||= Slack::Notifier.new(webhook_url, username: username)
     end
 
+    def filter_options(opts)
+      opts.select { |key, value| ALLOWED_PARAMS.include? key }
+    end
+
     def receive(incoming_events)
       incoming_events.each do |event|
         opts = interpolated(event)
+        slack_opts = filter_options(opts)
         if /^:/.match(opts[:icon])
-          slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username], icon_emoji: opts[:icon], unfurl_links: opts[:unfurl_links]
+          slack_opts[:icon_emoji] = opts[:icon]
         else
-          slack_notifier.ping opts[:message], channel: opts[:channel], username: opts[:username], icon_url: opts[:icon], unfurl_links: opts[:unfurl_links]
+          slack_opts[:icon_url] = opts[:icon]
         end
+        slack_notifier.ping opts[:message], slack_opts
       end
     end
   end


### PR DESCRIPTION
To address #1047, this uses a whitelist of fields that the Slack endpoint will accept. The icon logic is retained, so the only difference should be allowing the `attachments` parameter when it's present.

Running this with an agent like:
```
{
  "webhook_url": "https://hooks.slack.com/services/foo/bar",
  "channel": "#huginn-test",
  "username": "Dispatch Test",
  "message": "This should have an attachment.",
  "icon": ":bird:",
  "attachments": [
    {
      "fallback": "The fallback text.",
      "color": "#ff0080",
      "title": "Test Attachment",
      "title_link": "http://google.com"
    }
  ]
}
```
will produce:
![slack-attachment](https://cloud.githubusercontent.com/assets/451959/10224927/f6cdeaa4-6825-11e5-8708-6d3c22785e1f.PNG)
