### PR TITLE
Enable attachments in the Slack agent.

### DIFF
--- a/app/models/agents/slack_agent.rb
+++ b/app/models/agents/slack_agent.rb
@@ -14,7 +14,7 @@ module Agents
       #{'## Include `slack-notifier` in your Gemfile to use this Agent!' if dependencies_missing?}
 
       To get started, you will first need to configure an incoming webhook.
-      
+
       - Go to `https://my.slack.com/services/new/incoming-webhook`, choose a default channel and add the integration.
 
       Your webhook URL will look like: `https://hooks.slack.com/services/some/random/characters`
@@ -74,7 +74,7 @@ module Agents
       incoming_events.each do |event|
         opts = interpolated(event)
         slack_opts = filter_options(opts)
-        if opts[:icon].to_s != ''
+        if opts[:icon].present?
           if /^:/.match(opts[:icon])
             slack_opts[:icon_emoji] = opts[:icon]
           else

--- a/spec/models/agents/slack_agent_spec.rb
+++ b/spec/models/agents/slack_agent_spec.rb
@@ -2,11 +2,14 @@ require 'spec_helper'
 
 describe Agents::SlackAgent do
   before(:each) do
+    @fallback = "Its going to rain"
+    @attachments = [{'fallback' => "{{fallback}}"}]
     @valid_params = {
                       'webhook_url' => 'https://hooks.slack.com/services/random1/random2/token',
                       'channel' => '#random',
                       'username' => "{{username}}",
-                      'message' => "{{message}}"
+                      'message' => "{{message}}",
+                      'attachments' => @attachments
                     }
 
     @checker = Agents::SlackAgent.new(:name => "slacker", :options => @valid_params)
@@ -15,7 +18,7 @@ describe Agents::SlackAgent do
 
     @event = Event.new
     @event.agent = agents(:bob_weather_agent)
-    @event.payload = { :channel => '#random', :message => 'Looks like its going to rain', username: "Huggin user"}
+    @event.payload = { :channel => '#random', :message => 'Looks like its going to rain', username: "Huggin user", fallback: @fallback}
     @event.save!
   end
 
@@ -44,12 +47,22 @@ describe Agents::SlackAgent do
       @checker.options['icon_emoji'] = "something"
       expect(@checker).to be_valid
     end
+
+    it "should allow attachments" do
+      @checker.options['attachments'] = nil
+      expect(@checker).to be_valid
+      @checker.options['attachments'] = []
+      expect(@checker).to be_valid
+      @checker.options['attachments'] = @attachments
+      expect(@checker).to be_valid
+    end
   end
 
   describe "#receive" do
     it "receive an event without errors" do
       any_instance_of(Slack::Notifier) do |obj|
         mock(obj).ping(@event.payload[:message],
+                       attachments: [{'fallback' => @fallback}],
                        channel: @event.payload[:channel],
                        username: @event.payload[:username]
                       )


### PR DESCRIPTION
To resolve #1047, this allows the `attachments` property to be passed in the Slack notifier.

Setting up an agent like:
```
{
  "webhook_url": "https://hooks.slack.com/services/foo/bar/baz",
  "channel": "#huginn-test",
  "username": "Dispatch Test",
  "message": "This should have an attachment.",
  "icon": ":bird:",
  "attachments": [
    {
      "fallback": "The fallback text.",
      "color": "#ff0080",
      "title": "Test Attachment",
      "title_link": "http://google.com"
    }
  ]
}
```
will output:
![slack-attachment](https://cloud.githubusercontent.com/assets/451959/10231962/69962e32-684b-11e5-8b12-3d830f277614.PNG)