### PR TITLE
Procfile respects 12 factor port and IP

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -3,7 +3,7 @@
 ###############################
 
 # Procfile for development using the new threaded worker (scheduler, twitter stream and delayed job)
-web: bundle exec rails server -b0.0.0.0
+web: bundle exec rails server -p ${PORT-3000} -b ${IP-0.0.0.0}
 jobs: bundle exec rails runner bin/threaded.rb
 
 # Old version with separate processes (use this if you have issues with the threaded version)


### PR DESCRIPTION
I'm using c9.io for development and it configures the port and ip through environment variables. Since this seems to play nice with 12-factor principles, it seemed like a change that would be helpful for other situations too.