### PR TITLE
force-stopping services

### DIFF
--- a/lib/tasks/production.rake
+++ b/lib/tasks/production.rake
@@ -38,6 +38,11 @@ namespace :production do
     run_sv('start')
   end
 
+  task :force_stop => :check do
+    puts "Force stopping huginn ..."
+    run_sv('force-stop')
+  end
+
   task :status => :check do
     run_sv('status')
   end


### PR DESCRIPTION
As our huginn install grows sometimes `sv stop /etc/service/huginn-jobs` fails because of timeout error and to be able to deploy the new version you need to `kill -9` those processes.

`force-stop` is similar to `stop` except when the process doesn't respond, it kills it (and not throwing timeouterror)