### PR TITLE
Fetch post's data after publishing to tumblr

### DIFF
--- a/spec/models/agents/tumblr_publish_agent_spec.rb
+++ b/spec/models/agents/tumblr_publish_agent_spec.rb
@@ -1,38 +1,87 @@
 require 'spec_helper'
 
 describe Agents::TumblrPublishAgent do
-  before do
-    @opts = {
-      :blog_name => "huginnbot.tumblr.com",
-      :post_type => "text",
-      :expected_update_period_in_days => "2",
-      :options => {
-        :title => "{{title}}",
-        :body => "{{body}}",
-      },
-    }
+  describe "Should create post" do
+    before do
+      @opts = {
+        :blog_name => "huginnbot.tumblr.com",
+        :post_type => "text",
+        :expected_update_period_in_days => "2",
+        :options => {
+          :title => "{{title}}",
+          :body => "{{body}}",
+        },
+      }
 
-    @checker = Agents::TumblrPublishAgent.new(:name => "HuginnBot", :options => @opts)
-    @checker.service = services(:generic)
-    @checker.user = users(:bob)
-    @checker.save!
+      @checker = Agents::TumblrPublishAgent.new(:name => "HuginnBot", :options => @opts)
+      @checker.service = services(:generic)
+      @checker.user = users(:bob)
+      @checker.save!
 
-    @event = Event.new
-    @event.agent = agents(:bob_weather_agent)
-    @event.payload = { :title => "Gonna rain...", :body => 'San Francisco is gonna get wet' }
-    @event.save!
+      @event = Event.new
+      @event.agent = agents(:bob_weather_agent)
+      @event.payload = { :title => "Gonna rain...", :body => 'San Francisco is gonna get wet' }
+      @event.save!
 
-    stub.any_instance_of(Agents::TumblrPublishAgent).tumblr {
-      stub!.text(anything, anything) { { "id" => "5" } }
-    }
+      @post_body = {
+        "id" => 5,
+        "title" => "Gonna rain...",
+        "link" => "http://huginnbot.tumblr.com/gonna-rain..."
+      }
+      stub.any_instance_of(Agents::TumblrPublishAgent).tumblr {
+        obj = Object.new
+        stub(obj).text(anything, anything) { { "id" => "5" } }
+        stub(obj).posts("huginnbot.tumblr.com", {:id => "5"}) {
+          {"posts" => [@post_body]}
+        }
+      }
+
+    end
+
+    describe '#receive' do
+      it 'should publish any payload it receives' do
+        Agents::TumblrPublishAgent.async_receive(@checker.id, [@event.id])
+        expect(@checker.events.count).to eq(1)
+        expect(@checker.events.first.payload['post_id']).to eq('5')
+        expect(@checker.events.first.payload['published_post']).to eq('[huginnbot.tumblr.com] text')
+        expect(@checker.events.first.payload["post"]).to eq @post_body
+      end
+    end
   end
 
-  describe '#receive' do
-    it 'should publish any payload it receives' do
-      Agents::TumblrPublishAgent.async_receive(@checker.id, [@event.id])
-      expect(@checker.events.count).to eq(1)
-      expect(@checker.events.first.payload['post_id']).to eq('5')
-      expect(@checker.events.first.payload['published_post']).to eq('[huginnbot.tumblr.com] text')
+  describe "Should handle tumblr error" do
+    before do
+      @opts = {
+        :blog_name => "huginnbot.tumblr.com",
+        :post_type => "text",
+        :expected_update_period_in_days => "2",
+        :options => {
+          :title => "{{title}}",
+          :body => "{{body}}",
+        },
+      }
+
+      @checker = Agents::TumblrPublishAgent.new(:name => "HuginnBot", :options => @opts)
+      @checker.service = services(:generic)
+      @checker.user = users(:bob)
+      @checker.save!
+
+      @event = Event.new
+      @event.agent = agents(:bob_weather_agent)
+      @event.payload = { :title => "Gonna rain...", :body => 'San Francisco is gonna get wet' }
+      @event.save!
+
+      stub.any_instance_of(Agents::TumblrPublishAgent).tumblr {
+        stub!.text(anything, anything) { {"status" => 401,"msg" => "Not Authorized"} }
+      }
+    end
+
+    describe '#receive' do
+      it 'should publish any payload it receives and handle error' do
+        Agents::TumblrPublishAgent.async_receive(@checker.id, [@event.id])
+        puts "events #{@checker.events.inspect}"
+        expect(@checker.events.count).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
This is the first PR of #1084.

After publishing post to tumblr we should also fetch the post's metadata, it will include link, title, reblog_key. The returned value of the post is available in `event.payload["post"]`. Of course we could merge this into `event.payload` to keep payload flat but probably this would be a breaking change. It's easier to keep it under a "namespace".

Also I fixed a small issue, tumblr agent was creating success event even though the publish failed.

Spec attached.