### PR TITLE
Allow custom response message to be optionally set for the WebhookAgent

### DIFF
--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -73,7 +73,7 @@ module Agents
     end
 
     def response_message
-      options['response'] || 'Event Created'
+      interpolated['response'] || 'Event Created'
     end
   end
 end

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -23,6 +23,7 @@ module Agents
         * `verbs` - Comma-separated list of http verbs your agent will accept.
           For example, "post,get" will enable POST and GET requests. Defaults
           to "post".
+        * `response` - The response message to the request. Defaults to 'Event Created'.
       MD
     end
 
@@ -36,7 +37,8 @@ module Agents
     def default_options
       { "secret" => "supersecretstring",
         "expected_receive_period_in_days" => 1,
-        "payload_path" => "some_key"
+        "payload_path" => "some_key",
+        "response" => "Event Created"
       }
     end
 
@@ -53,7 +55,7 @@ module Agents
         create_event(payload: payload)
       end
 
-      ['Event Created', 201]
+      [response_message, 201]
     end
 
     def working?
@@ -68,6 +70,10 @@ module Agents
 
     def payload_for(params)
       Utils.value_at(params, interpolated['payload_path']) || {}
+    end
+
+    def response_message
+      options['response'] || 'Event Created'
     end
   end
 end

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -38,6 +38,20 @@ describe Agents::WebhookAgent do
       expect(out).to eq(['Not Authorized', 401])
     end
 
+    it 'should respond with customized response message if configured with `response` option' do
+      out = nil
+      agent.options['response'] = 'That Worked'
+      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      expect(out).to eq(['That Worked', 201])
+    end
+
+    it 'should respond with `Event Created` if response option is nil' do
+      out = nil
+      agent.options['response'] = nil
+      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      expect(out).to eq(['Event Created', 201])
+    end
+
     describe "receiving events" do
 
       context "default settings" do


### PR DESCRIPTION
Covers what was discussed in #1087 

I added a couple rspec tests and everything seems to cover the needs I raised in the original thread.