### PR TITLE
Fix support for postgresql adapter in Docker container

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ There is an exported docker volume of /var/lib/mysql to allow persistence of tha
 
 Additionally, the database variables may be overridden from the above as per the standard Huginn documentation:
 
-    HUGINN_DATABASE_ADAPTER #(must be either 'postgres' or 'mysql2')
+    HUGINN_DATABASE_ADAPTER #(must be either 'postgresql' or 'mysql2')
     HUGINN_DATABASE_HOST
     HUGINN_DATABASE_PORT
 

--- a/docker/scripts/init
+++ b/docker/scripts/init
@@ -19,7 +19,7 @@ if [ -n "${MYSQL_PORT_3306_TCP_ADDR}" ]; then
   HUGINN_DATABASE_HOST=${HUGINN_DATABASE_HOST:-${MYSQL_PORT_3306_TCP_ADDR}}
   HUGINN_DATABASE_PORT=${HUGINN_DATABASE_PORT:-${MYSQL_PORT_3306_TCP_PORT}}
 elif [ -n "${POSTGRESQL_PORT_5432_TCP_ADDR}" ]; then
-  HUGINN_DATABASE_ADAPTER=${HUGINN_DATABASE_ADAPTER:-postgres}
+  HUGINN_DATABASE_ADAPTER=${HUGINN_DATABASE_ADAPTER:-postgresql}
   HUGINN_DATABASE_HOST=${HUGINN_DATABASE_HOST:-${POSTGRESQL_PORT_5432_TCP_ADDR}}
   HUGINN_DATABASE_PORT=${HUGINN_DATABASE_PORT:-${POSTGRESQL_PORT_5432_TCP_PORT}}
 fi
@@ -39,9 +39,13 @@ USE_GRAPHVIZ_DOT=${HUGINN_USE_GRAPHVIZ_DOT:-${USE_GRAPHVIZ_DOT}}
 # use default port number if it is still not set
 case "${DATABASE_ADAPTER}" in
   mysql2) DATABASE_PORT=${DATABASE_PORT:-3306} ;;
-  postgres) DATABASE_PORT=${DATABASE_PORT:-5432} ;;
-  *) echo "Unsupported database adapter. Available adapters are mysql2, and postgres." && exit 1 ;;
+  postgresql) DATABASE_PORT=${DATABASE_PORT:-5432} ;;
+  *) echo "Unsupported database adapter. Available adapters are mysql2, and postgresql." && exit 1 ;;
 esac
+
+if [ "${DATABASE_ADAPTER}" = "postgresql" ]; then
+  sed --in-place "s/gem 'mysql2'.*/gem 'pg'/" /app/Gemfile
+fi
 
 # initialize supervisord config
 
@@ -71,8 +75,8 @@ echo DATABASE_HOST=\${DATABASE_HOST}
 
 # start mysql server if \${DATABASE_HOST} is the .env.example default
 if [ "\${DATABASE_HOST}" = "your-domain-here.com" -o "\${DATABASE_HOST}" = "" ]; then
-  if [ "\${DATABASE_ADAPTER}" = "postgres" ]; then
-    echo "DATABASE_ADAPTER 'postgres' is not supported internally. Please provide DATABASE_HOST."
+  if [ "\${DATABASE_ADAPTER}" = "postgresql" ]; then
+    echo "DATABASE_ADAPTER 'postgresql' is not supported internally. Please provide DATABASE_HOST."
     exit 1
   fi
 


### PR DESCRIPTION
For running the docker container with my PostgreSQL DB, I had to change the adapater name and add the 'pg' gem to Gemfile. Not tested on Heroku.