### PR TITLE
Tumblr reblog post_type added

### DIFF
--- a/app/models/agents/tumblr_publish_agent.rb
+++ b/app/models/agents/tumblr_publish_agent.rb
@@ -173,7 +173,6 @@ module Agents
         options_obj[:comment] = options['comment']
         tumblr.reblog(blog_name, options_obj)
       end
-      end
     end
 
     def get_post(blog_name, id)

--- a/app/models/agents/tumblr_publish_agent.rb
+++ b/app/models/agents/tumblr_publish_agent.rb
@@ -19,7 +19,7 @@ module Agents
 
       `blog_name` Your Tumblr URL (e.g. "mustardhamsters.tumblr.com")
 
-      `post_type` One of [text, photo, quote, link, chat, audio, video]
+      `post_type` One of [text, photo, quote, link, chat, audio, video, reblog]
 
 
       -------------
@@ -49,6 +49,7 @@ module Agents
 
       **Video** `caption` `embed`
 
+      **Reblog** `id` `reblog_key` `comment`
 
       -------------
 
@@ -90,6 +91,9 @@ module Agents
           'conversation' => "{{conversation}}",
           'external_url' => "{{external_url}}",
           'embed' => "{{embed}}",
+          'id' => "{{id}}",
+          'reblog_key' => "{{reblog_key}}",
+          'comment' => "{{comment}}",
         },
       }
     end
@@ -163,6 +167,12 @@ module Agents
         options_obj[:caption] = options['caption']
         options_obj[:embed] = options['embed']
         tumblr.video(blog_name, options_obj)
+      when "reblog"
+        options_obj[:id] = options['id']
+        options_obj[:reblog_key] = options['reblog_key']
+        options_obj[:comment] = options['comment']
+        tumblr.reblog(blog_name, options_obj)
+      end
       end
     end
 


### PR DESCRIPTION
Added `reblog` post type to `TumblrPublishAgent`

Small use case:
1. Create a tumblr post
2. Reblog with a secondary blog

Since @cantino merged https://github.com/cantino/huginn/pull/1099 you'll have `id`, `reblog_key` to be able reblog a post.

Back to the use case:
1. `TumblrPublishAgent`
   ```
      {
          blog_name: "your_blog_name",
          post_type: "text",
          options: {
             title: "huginn is awesome",
             body: "i will be even able to reblog this"
          }
   ```
2. `TumblrPublishAgent`
   ```
      {
         blog_name: "your_blog_name2",
         post_type: "reblog",
         options: {
            id: "{{post.id}}",
            reblog_key: "{{post.reblog_key}}"
            comment: "I indeed was able to reblog \o/"
         }
      }
   ```

ps: I was too lazy to export a scenario for this:(