### PR TITLE
Do not emit all the events on DelayAgent#check

### DIFF
--- a/app/models/agents/delay_agent.rb
+++ b/app/models/agents/delay_agent.rb
@@ -11,13 +11,16 @@ module Agents
 
       `expected_receive_period_in_days` is used to determine if the Agent is working. Set it to the maximum number of days
       that you anticipate passing without this Agent receiving an incoming Event.
+
+      `max_emitted_events` is used to limit the number of the maximum events which should be created. If you omit this DelayAgent will create events for every event stored in the memory.
     MD
 
     def default_options
       {
         'expected_receive_period_in_days' => "10",
         'max_events' => "100",
-        'keep' => 'newest'
+        'keep' => 'newest',
+        'max_emitted_events' => "100"
       }
     end
 
@@ -55,10 +58,16 @@ module Agents
 
     def check
       if memory['event_ids'] && memory['event_ids'].length > 0
-        received_events.where(id: memory['event_ids']).reorder('events.id asc').each do |event|
-          create_event payload: event.payload
+        events = received_events.where(id: memory['event_ids']).reorder('events.id asc')
+
+        if options['max_emitted_events'].present?
+          events = events.slice(0, options['max_emitted_events'].to_i)
         end
-        memory['event_ids'] = []
+
+        events.each do |event|
+          create_event payload: event.payload
+          memory['event_ids'].delete(event.id)
+        end
       end
     end
   end

--- a/app/models/agents/delay_agent.rb
+++ b/app/models/agents/delay_agent.rb
@@ -60,7 +60,7 @@ module Agents
         events = received_events.where(id: memory['event_ids']).reorder('events.id asc')
 
         if options['max_emitted_events'].present?
-          events = events.slice(0, options['max_emitted_events'].to_i)
+          events = events.limit(options['max_emitted_events'].to_i)
         end
 
         events.each do |event|

--- a/app/models/agents/delay_agent.rb
+++ b/app/models/agents/delay_agent.rb
@@ -19,8 +19,7 @@ module Agents
       {
         'expected_receive_period_in_days' => "10",
         'max_events' => "100",
-        'keep' => 'newest',
-        'max_emitted_events' => "100"
+        'keep' => 'newest'
       }
     end
 

--- a/spec/models/agents/delay_agent_spec.rb
+++ b/spec/models/agents/delay_agent_spec.rb
@@ -108,5 +108,20 @@ describe Agents::DelayAgent do
 
       expect(agent.memory['event_ids']).to eq []
     end
+
+    it "re-emits max_emitted_events and clears just them from the memory" do
+      agent.options['max_emitted_events'] = 1
+      agent.receive([first_event, second_event, third_event])
+      expect(agent.memory['event_ids']).to eq [second_event.id, third_event.id]
+
+      expect {
+        agent.check
+      }.to change { agent.events.count }.by(1)
+
+      events = agent.events.reorder('events.id desc')
+      expect(agent.memory['event_ids']).to eq [third_event.id]
+      expect(events.first.payload).to eq second_event.payload
+
+    end
   end
 end


### PR DESCRIPTION
Usually we are filling up DelayAgents with hundred events and then we let it ticking by setting `max_emitted_events` to 1.

