### PR TITLE
Do check restarting LongRunnable::Worker for liveliness

### DIFF
--- a/app/models/agents/twitter_stream_agent.rb
+++ b/app/models/agents/twitter_stream_agent.rb
@@ -176,7 +176,7 @@ module Agents
 
       def stop
         EventMachine.stop_event_loop if EventMachine.reactor_running?
-        thread.terminate
+        terminate_thread!
       end
 
       private

--- a/lib/agent_runner.rb
+++ b/lib/agent_runner.rb
@@ -100,7 +100,7 @@ class AgentRunner
 
   def restart_dead_workers
     @workers.each_pair do |id, worker|
-      if worker.thread && !worker.thread.alive?
+      if !worker.restarting && worker.thread && !worker.thread.alive?
         puts "Restarting #{id.to_s}"
         @workers[id].run!
       end

--- a/spec/concerns/long_runnable_spec.rb
+++ b/spec/concerns/long_runnable_spec.rb
@@ -76,6 +76,14 @@ describe LongRunnable do
     context "#stop!" do
       it "terminates the thread" do
         mock(@worker.thread).terminate
+        mock(@worker.thread).status { 'run' }
+        @worker.stop!
+      end
+
+      it "wakes up sleeping threads after termination" do
+        mock(@worker.thread).terminate
+        mock(@worker.thread).status { 'sleep' }
+        mock(@worker.thread).wakeup
         @worker.stop!
       end
 

--- a/spec/models/agents/twitter_stream_agent_spec.rb
+++ b/spec/models/agents/twitter_stream_agent_spec.rb
@@ -193,6 +193,7 @@ describe Agents::TwitterStreamAgent do
     context "#stop" do
       it "stops the thread" do
         mock(@worker.thread).terminate
+        mock(@worker.thread).status
         @worker.stop
       end
     end


### PR DESCRIPTION
Fixes a memory leak caused by starting a new Worker when the old one is still restarting.

It required more testing and changes then I expected, but I have not seen any duplications for a week. Not entirely sure if the orphaned `TwitterAgent::Worker` were caused by the restart or the thread sleeping past its termination (fixed by waking up sleeping threads after terminating them).