### PR TITLE
Prevent buildup of threads in specs

### DIFF
--- a/app/concerns/long_runnable.rb
+++ b/app/concerns/long_runnable.rb
@@ -90,8 +90,12 @@ module LongRunnable
       if respond_to?(:stop)
         stop
       else
-        thread.terminate
+        terminate_thread
       end
+    end
+
+    def terminate_thread
+      thread.terminate if thread
     end
 
     def restart!
@@ -117,6 +121,7 @@ module LongRunnable
     end
 
     private
+
     def schedule(method, args, &blk)
       @scheduler.send(method, *args, tag: id, &blk)
     end

--- a/lib/agent_runner.rb
+++ b/lib/agent_runner.rb
@@ -17,12 +17,10 @@ class AgentRunner
     @scheduler = Rufus::Scheduler.new(frequency: ENV['SCHEDULER_FREQUENCY'].presence || 0.3)
 
     @scheduler.every 5 do
-      p :every
       restart_dead_workers if @running
     end
 
     @scheduler.every 60 do
-      p :every
       run_workers if @running
     end
 

--- a/lib/delayed_job_worker.rb
+++ b/lib/delayed_job_worker.rb
@@ -7,7 +7,7 @@ class DelayedJobWorker < LongRunnable::Worker
   end
 
   def stop
-    @dj.stop
+    @dj.stop if @dj
   end
 
   def self.setup_worker

--- a/lib/huginn_scheduler.rb
+++ b/lib/huginn_scheduler.rb
@@ -145,6 +145,7 @@ class HuginnScheduler < LongRunnable::Worker
   end
 
   private
+
   def run_schedule(time)
     with_mutex do
       puts "Queuing schedule for #{time}"

--- a/spec/concerns/long_runnable_spec.rb
+++ b/spec/concerns/long_runnable_spec.rb
@@ -9,7 +9,7 @@ describe LongRunnable do
     end
   end
 
-  before(:all) do
+  before(:each) do
     @agent = LongRunnableAgent.new
   end
 
@@ -41,7 +41,13 @@ describe LongRunnable do
     before(:each) do
       @agent = Object.new
       @worker = LongRunnable::Worker.new(agent: @agent, id: 'test1234')
-      @worker.setup!(Rufus::Scheduler.new, Mutex.new)
+      @scheduler = Rufus::Scheduler.new
+      @worker.setup!(@scheduler, Mutex.new)
+    end
+
+    after(:each) do
+      @worker.thread.terminate if @worker.thread
+      @scheduler.shutdown(:wait)
     end
 
     it "calls boolify of the agent" do
@@ -75,7 +81,7 @@ describe LongRunnable do
 
     context "#stop!" do
       it "terminates the thread" do
-        mock(@worker.thread).terminate
+        mock.proxy(@worker).terminate_thread
         @worker.stop!
       end
 

--- a/spec/lib/agent_runner_spec.rb
+++ b/spec/lib/agent_runner_spec.rb
@@ -8,10 +8,14 @@ describe AgentRunner do
       @agent_runner = AgentRunner.new
     end
 
+    after(:each) do
+      @agent_runner.stop
+      AgentRunner.class_variable_set(:@@agents, [])
+    end
+
     context "#run" do
       before do
         mock(@agent_runner).run_workers
-        mock.instance_of(IO).puts('Stopping AgentRunner...')
       end
 
       it "runs until stop is called" do
@@ -30,6 +34,7 @@ describe AgentRunner do
       before do
         AgentRunner.class_variable_set(:@@agents, [HuginnScheduler, DelayedJobWorker])
       end
+
       it "loads all workers" do
         workers = @agent_runner.send(:load_workers)
         expect(workers).to be_a(Hash)
@@ -37,27 +42,29 @@ describe AgentRunner do
       end
 
       it "loads only the workers specified in the :only option" do
-        @agent_runner = AgentRunner.new(only: HuginnScheduler)
-        workers = @agent_runner.send(:load_workers)
+        agent_runner = AgentRunner.new(only: HuginnScheduler)
+        workers = agent_runner.send(:load_workers)
         expect(workers.keys).to eq(['HuginnScheduler'])
+        agent_runner.stop
       end
 
       it "does not load workers specified in the :except option" do
-        @agent_runner = AgentRunner.new(except: HuginnScheduler)
-        workers = @agent_runner.send(:load_workers)
+        agent_runner = AgentRunner.new(except: HuginnScheduler)
+        workers = agent_runner.send(:load_workers)
         expect(workers.keys).to eq(['DelayedJobWorker'])
+
+        agent_runner.stop
       end
     end
 
     context "running workers" do
       before do
         AgentRunner.class_variable_set(:@@agents, [HuginnScheduler, DelayedJobWorker])
-        stub.instance_of(IO).puts
-        stub.instance_of(LongRunnable::Worker).setup!
+        stub.instance_of(HuginnScheduler).setup
+        stub.instance_of(DelayedJobWorker).setup
       end
 
       context "#run_workers" do
-
         it "runs all the workers" do
           mock.instance_of(HuginnScheduler).run!
           mock.instance_of(DelayedJobWorker).run!
@@ -97,6 +104,8 @@ describe AgentRunner do
       mock(Signal).trap('TERM')
       mock(Signal).trap('QUIT')
       agent_runner.set_traps
+
+      agent_runner.stop
     end
   end
 end

--- a/spec/lib/agents_exporter_spec.rb
+++ b/spec/lib/agents_exporter_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'rails_helper'
 
 describe AgentsExporter do

--- a/spec/lib/huginn_scheduler_spec.rb
+++ b/spec/lib/huginn_scheduler_spec.rb
@@ -3,16 +3,20 @@ require 'huginn_scheduler'
 
 describe HuginnScheduler do
   before(:each) do
+    @rufus_scheduler = Rufus::Scheduler.new
     @scheduler = HuginnScheduler.new
     stub(@scheduler).setup {}
-    @scheduler.setup!(Rufus::Scheduler.new, Mutex.new)
-    stub
+    @scheduler.setup!(@rufus_scheduler, Mutex.new)
+  end
+
+  after(:each) do
+    @rufus_scheduler.shutdown(:wait)
   end
 
   it "schould register the schedules with the rufus scheduler and run" do
-    mock.instance_of(Rufus::Scheduler).join
+    mock(@rufus_scheduler).join
     scheduler = HuginnScheduler.new
-    scheduler.setup!(Rufus::Scheduler.new, Mutex.new)
+    scheduler.setup!(@rufus_scheduler, Mutex.new)
     scheduler.run
   end
 
@@ -87,6 +91,8 @@ end
 
 describe Rufus::Scheduler do
   before :each do
+    Agent.delete_all
+
     @taoe, Thread.abort_on_exception = Thread.abort_on_exception, false
     @oso, @ose, $stdout, $stderr = $stdout, $stderr, StringIO.new, StringIO.new
 
@@ -105,7 +111,7 @@ describe Rufus::Scheduler do
   end
 
   after :each do
-    @scheduler.shutdown
+    @scheduler.shutdown(:wait)
 
     Thread.abort_on_exception = @taoe
     $stdout, $stderr = @oso, @ose


### PR DESCRIPTION
@dsander, I added

```ruby
config.after(:each) do |example| 
  sleep 1
  p example.metadata[:full_description]
  pp Thread.list.map { |t| t[:name] || t[:rufus_scheduler_work_thread] || t == Thread::main } 
end 
```

to my rails_helper.rb and saw a large number of lines like `"rufus_scheduler_70250065071700_scheduler"`.  The following changes got rid of them.