### PR TITLE
Bump nokogiri and uglifier for security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem 'liquid', '~> 3.0.3'
 gem 'mini_magick'
 gem 'mysql2', '~> 0.3.16'
 gem 'multi_xml'
-gem 'nokogiri', '~> 1.6.4'
+gem 'nokogiri', '1.6.7.rc4'
 gem 'omniauth'
 gem 'rails', '4.2.4'
 gem 'rufus-scheduler', '~> 3.0.8', require: false
@@ -95,7 +95,7 @@ gem 'spectrum-rails'
 gem 'string-scrub'	# for ruby <2.1
 gem 'therubyracer', '~> 0.12.2'
 gem 'typhoeus', '~> 0.6.3'
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier', '~> 2.7.2'
 
 group :development do
   gem 'better_errors', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     evernote_oauth (0.2.3)
       evernote-thrift
       oauth (>= 0.4.1)
-    execjs (2.3.0)
+    execjs (2.6.0)
     extlib (0.9.16)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
@@ -298,7 +298,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.6.1)
     mini_magick (4.2.3)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0.rc2)
     minitest (5.8.1)
     mqtt (0.3.1)
     multi_json (1.11.2)
@@ -311,8 +311,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
     netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.rc4)
+      mini_portile2 (~> 2.0.0.rc2)
     oauth (0.4.7)
     oauth2 (0.9.4)
       faraday (>= 0.8, < 0.10)
@@ -510,7 +510,7 @@ GEM
       ethon (>= 0.7.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.0)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unf (0.1.4)
@@ -587,7 +587,7 @@ DEPENDENCIES
   multi_xml
   mysql2 (~> 0.3.16)
   net-ftp-list (~> 3.2.8)
-  nokogiri (~> 1.6.4)
+  nokogiri (= 1.6.7.rc4)
   omniauth
   omniauth-37signals
   omniauth-dropbox
@@ -624,7 +624,7 @@ DEPENDENCIES
   typhoeus (~> 0.6.3)
   tzinfo (>= 1.2.0)
   tzinfo-data
-  uglifier (>= 1.3.0)
+  uglifier (~> 2.7.2)
   unicorn (~> 4.9.0)
   vcr
   webmock (~> 1.17.4)


### PR DESCRIPTION
Two security updates for our dependencies.

* Uglifier: https://zyan.scripts.mit.edu/blog/backdooring-js/
* Nokogiri: https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.rdoc#167rc4--2015-11-22

@dsander 