### PR TITLE
Export Agents in GUID order for consistent ordering [#1174]

### DIFF
--- a/lib/agents_exporter.rb
+++ b/lib/agents_exporter.rb
@@ -27,7 +27,7 @@ class AgentsExporter
   end
 
   def agents
-    options[:agents].to_a
+    options[:agents].sort_by{|agent| agent.guid}.to_a
   end
 
   def links

--- a/spec/lib/agents_exporter_spec.rb
+++ b/spec/lib/agents_exporter_spec.rb
@@ -23,27 +23,27 @@ describe AgentsExporter do
       expect(data[:tag_fg_color]).to eq(tag_fg_color)
       expect(data[:tag_bg_color]).to eq(tag_bg_color)
       expect(Time.parse(data[:exported_at])).to be_within(2).of(Time.now.utc)
-      expect(data[:links]).to eq([{ :source => 0, :receiver => 1 }])
+      expect(data[:links]).to eq([{ :source => guid_order(agent_list, :jane_weather_agent), :receiver => guid_order(agent_list, :jane_rain_notifier_agent)}])
       expect(data[:control_links]).to eq([])
-      expect(data[:agents]).to eq(agent_list.map { |agent| exporter.agent_as_json(agent) })
+      expect(data[:agents]).to eq(agent_list.sort_by{|a| a.guid}.map { |agent| exporter.agent_as_json(agent) })
       expect(data[:agents].all? { |agent_json| agent_json[:guid].present? && agent_json[:type].present? && agent_json[:name].present? }).to be_truthy
 
-      expect(data[:agents][0]).not_to have_key(:propagate_immediately) # can't receive events
-      expect(data[:agents][1]).not_to have_key(:schedule) # can't be scheduled
+      expect(data[:agents][guid_order(agent_list, :jane_weather_agent)]).not_to have_key(:propagate_immediately) # can't receive events
+      expect(data[:agents][guid_order(agent_list, :jane_rain_notifier_agent)]).not_to have_key(:schedule) # can't be scheduled
     end
 
     it "does not output links to other agents outside of the incoming set" do
       Link.create!(:source_id => agents(:jane_weather_agent).id, :receiver_id => agents(:jane_website_agent).id)
       Link.create!(:source_id => agents(:jane_website_agent).id, :receiver_id => agents(:jane_rain_notifier_agent).id)
 
-      expect(exporter.as_json[:links]).to eq([{ :source => 0, :receiver => 1 }])
+      expect(exporter.as_json[:links]).to eq([{ :source => guid_order(agent_list, :jane_weather_agent), :receiver => guid_order(agent_list, :jane_rain_notifier_agent) }])
     end
 
     it "outputs control links to agents within the incoming set, but not outside it" do
       agents(:jane_rain_notifier_agent).control_targets = [agents(:jane_weather_agent), agents(:jane_basecamp_agent)]
       agents(:jane_rain_notifier_agent).save!
 
-      expect(exporter.as_json[:control_links]).to eq([{ :controller => 1, :control_target => 0 }])
+      expect(exporter.as_json[:control_links]).to eq([{ :controller => guid_order(agent_list, :jane_rain_notifier_agent), :control_target => guid_order(agent_list, :jane_weather_agent) }])
     end
   end
 
@@ -70,5 +70,9 @@ describe AgentsExporter do
       expect(AgentsExporter.new(:name => "-").filename).to eq("exported-agents.json")
       expect(AgentsExporter.new(:name => ",,").filename).to eq("exported-agents.json")
     end
+  end
+
+  def guid_order(agent_list, agent_name)
+    agent_list.map{|a|a.guid}.sort.find_index(agents(agent_name).guid)
   end
 end


### PR DESCRIPTION
Export Agents in GUID order so that the result is amenable to version control tracking

Addresses #1174