### PR TITLE
Add new block tags `regex_replace`/`regex_replace_first` to Liquid

### DIFF
--- a/app/concerns/liquid_droppable.rb
+++ b/app/concerns/liquid_droppable.rb
@@ -33,6 +33,34 @@ module LiquidDroppable
     self.class::Drop.new(self)
   end
 
+  class MatchDataDrop < Liquid::Drop
+    def initialize(object)
+      @object = object
+    end
+
+    %w[pre_match post_match names size].each { |attr|
+      define_method(attr) {
+        @object.__send__(attr)
+      }
+    }
+
+    def to_s
+      @object[0]
+    end
+
+    def before_method(method)
+      @object[method]
+    rescue IndexError
+      nil
+    end
+  end
+
+  class ::MatchData
+    def to_liquid
+      MatchDataDrop.new(self)
+    end
+  end
+
   require 'uri'
 
   class URIDrop < Drop

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -220,4 +220,38 @@ describe LiquidInterpolatable::Filters do
       expect(agent.interpolated['test']).to eq("foo\\1\nfoobar\\\nfoobaz\\")
     end
   end
+
+  describe 'regex_replace_first block' do
+    let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
+
+    it 'should replace the first occurrence of a string using regex' do
+      agent.interpolation_context['something'] = 'foobar zoobar'
+      agent.options['cleaned'] = '{% regex_replace_first "(?<word>\S+)(?<suffix>bar)" in %}{{ something }}{% with %}{{ word | upcase }}{{ suffix }}{% endregex_replace_first %}'
+      expect(agent.interpolated['cleaned']).to eq('FOObar zoobar')
+    end
+
+    it 'should be able to take a pattern in a variable' do
+      agent.interpolation_context['something'] = 'foobar zoobar'
+      agent.interpolation_context['pattern'] = "(?<word>\\S+)(?<suffix>bar)"
+      agent.options['cleaned'] = '{% regex_replace_first pattern in %}{{ something }}{% with %}{{ word | upcase }}{{ suffix }}{% endregex_replace_first %}'
+      expect(agent.interpolated['cleaned']).to eq('FOObar zoobar')
+    end
+
+    it 'should define a variable named "match" in a "with" block' do
+      agent.interpolation_context['something'] = 'foobar zoobar'
+      agent.interpolation_context['pattern'] = "(?<word>\\S+)(?<suffix>bar)"
+      agent.options['cleaned'] = '{% regex_replace_first pattern in %}{{ something }}{% with %}{{ match.word | upcase }}{{ match["suffix"] }}{% endregex_replace_first %}'
+      expect(agent.interpolated['cleaned']).to eq('FOObar zoobar')
+    end
+  end
+
+  describe 'regex_replace block' do
+    let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
+
+    it 'should replace the all occurrences of a string using regex' do
+      agent.interpolation_context['something'] = 'foobar zoobar'
+      agent.options['cleaned'] = '{% regex_replace "(?<word>\S+)(?<suffix>bar)" in %}{{ something }}{% with %}{{ word | upcase }}{{ suffix }}{% endregex_replace %}'
+      expect(agent.interpolated['cleaned']).to eq('FOObar ZOObar')
+    end
+  end
 end


### PR DESCRIPTION
This allows user to perform dynamic substitution using the power of Liquid templating itself.