### PR TITLE
Fix mysql connection check for multi-process docker image

### DIFF
--- a/docker/multi-process/scripts/init
+++ b/docker/multi-process/scripts/init
@@ -118,7 +118,7 @@ EOF
 
   # wait for mysql server to start (max 120 seconds)
   timeout=120
-  while ! mysqladmin -u root status >/dev/null 2>&1
+  while ! mysqladmin -u root status >/dev/null 2>&1 && ! mysqladmin -u root --password=\${DATABASE_PASSWORD} status >/dev/null 2>&1
   do
     (( timeout = timeout - 1 ))
     if [ \$timeout -eq 0 ]; then


### PR DESCRIPTION
Fixes #1241 

@mhow2 Do you mind testing this?

You can inject the changed script into your running container like so:
```
wget https://raw.githubusercontent.com/dsander/huginn/d57ca61026386ceaa026afb5cc045a2a8003a10c/docker/multi-process/scripts/init
docker cp init <container name>:/scripts/init
docker stop <container name>
docker start <container name>
```