### PR TITLE
The GoogleCalendarPublishAgent now accepts Liquid in the calendar_id option

### DIFF
--- a/app/models/agents/google_calendar_publish_agent.rb
+++ b/app/models/agents/google_calendar_publish_agent.rb
@@ -31,7 +31,7 @@ module Agents
 
       `google` `service_account_email` - The authorised service account.
 
-      `google` `key_file` - The path to the key file.
+      `google` `key_file` OR `google` `key` - The path to the key file or the key itself.  Liquid formatting is supported if you want to use a Credential.  (E.g., `{% credential google_key %}`)
 
       `google` `key_secret` - The secret for the key, typically 'notasecret'
 
@@ -91,7 +91,7 @@ module Agents
 
     def receive(incoming_events)
      incoming_events.each do |event|
-        calendar = GoogleCalendar.new(options, Rails.logger)
+        calendar = GoogleCalendar.new(interpolate_options(options, event), Rails.logger)
 
         calendar_event = JSON.parse(calendar.publish_as(interpolated(event)['calendar_id'], event.payload["message"]).response.body)
 

--- a/app/models/agents/google_calendar_publish_agent.rb
+++ b/app/models/agents/google_calendar_publish_agent.rb
@@ -25,7 +25,7 @@ module Agents
 
       Agent Configuration:
 
-      `calendar_id` - The id the calendar you want to publish to. Typically your google account email address.
+      `calendar_id` - The id the calendar you want to publish to. Typically your google account email address.  Liquid formatting (e.g. `{{ cal_id }}`) is allowed here in order to extract the calendar_id from the incoming event.
 
       `google` A hash of configuration options for the agent.
 
@@ -35,7 +35,6 @@ module Agents
 
       `google` `key_secret` - The secret for the key, typically 'notasecret'
 
-      
 
       Set `expected_update_period_in_days` to the maximum amount of time that you'd expect to pass between Events being created by this Agent.
 
@@ -94,8 +93,8 @@ module Agents
      incoming_events.each do |event|
         calendar = GoogleCalendar.new(options, Rails.logger)
 
-        calendar_event = JSON.parse(calendar.publish_as(options['calendar_id'], event.payload["message"]).response.body)
-  
+        calendar_event = JSON.parse(calendar.publish_as(interpolated(event)['calendar_id'], event.payload["message"]).response.body)
+
         create_event :payload => {
           'success' => true,
           'published_calendar_event' => calendar_event,

--- a/lib/google_calendar.rb
+++ b/lib/google_calendar.rb
@@ -1,7 +1,13 @@
 class GoogleCalendar
   def initialize(config, logger)
     @config = config
-    @key = Google::APIClient::PKCS12.load_key(@config['google']['key_file'], @config['google']['key_secret'])
+
+    if @config['google']['key'].present?
+      @key = OpenSSL::PKCS12.new(@config['google']['key'], @config['google']['key_secret']).key
+    else
+      @key = Google::APIClient::PKCS12.load_key(@config['google']['key_file'], @config['google']['key_secret'])
+    end
+
     @client = Google::APIClient.new(application_name: "Huginn", application_version: "0.0.1")
     @client.retries = 2
     @logger ||= logger

--- a/spec/models/agents/google_calendar_publish_agent_spec.rb
+++ b/spec/models/agents/google_calendar_publish_agent_spec.rb
@@ -1,43 +1,104 @@
 require 'rails_helper'
 
 describe Agents::GoogleCalendarPublishAgent, :vcr do
-  before do
-    @valid_params = {
-        'expected_update_period_in_days' => "10",
-        'calendar_id' => 'sqv39gj35tc837gdns1g4d81cg@group.calendar.google.com',
-        'google' => {
-          'key_file' => File.dirname(__FILE__) + '/../../data_fixtures/private.key',
-          'key_secret' => 'notasecret',
-          'service_account_email' => '1029936966326-ncjd7776pcspc98hsg82gsb56t3217ef@developer.gserviceaccount.com'
-        }
+  let(:valid_params) do
+    {
+      'expected_update_period_in_days' => "10",
+      'calendar_id' => calendar_id,
+      'google' => {
+        'key_file' => File.dirname(__FILE__) + '/../../data_fixtures/private.key',
+        'key_secret' => 'notasecret',
+        'service_account_email' => '1029936966326-ncjd7776pcspc98hsg82gsb56t3217ef@developer.gserviceaccount.com'
       }
-    @checker = Agents::GoogleCalendarPublishAgent.new(:name => "somename", :options => @valid_params)
-    @checker.user = users(:jane)
-    @checker.save!
+    }
+  end
+
+  let(:agent) do
+    _agent = Agents::GoogleCalendarPublishAgent.new(name: "somename", options: valid_params)
+    _agent.user = users(:jane)
+    _agent.save!
+    _agent
   end
 
   describe '#receive' do
-    it 'should publish any payload it receives' do
-      event1 = Event.new
-      event1.agent = agents(:bob_manual_event_agent)
-      event1.payload = {
-        'message' => { 
-          'visibility' => 'default',
-          'summary' => "Awesome event",
-          'description' => "An example event with text. Pro tip: DateTimes are in RFC3339",
-          'end' => {
-            'dateTime' => '2014-10-02T11:00:00-05:00'
-          },
-          'start' => {
-            'dateTime' => '2014-10-02T10:00:00-05:00'
-          }
+    let(:event) do
+      _event = Event.new
+      _event.agent = agents(:bob_manual_event_agent)
+      _event.payload = { 'message' => message }
+      _event.save!
+      _event
+    end
+
+    let(:calendar_id) { 'sqv39gj35tc837gdns1g4d81cg@group.calendar.google.com' }
+    let(:message) do
+      {
+        'visibility' => 'default',
+        'summary' => "Awesome event",
+        'description' => "An example event with text. Pro tip: DateTimes are in RFC3339",
+        'end' => {
+          'dateTime' => '2014-10-02T11:00:00-05:00'
+        },
+        'start' => {
+          'dateTime' => '2014-10-02T10:00:00-05:00'
         }
       }
-      event1.save!
+    end
+    let(:response_body) do
+      {"kind"=>"calendar#event",
+        "etag"=>"\"2908684044040000\"",
+        "id"=>"baz",
+        "status"=>"confirmed",
+        "htmlLink"=>
+          "https://calendar.google.com/calendar/event?eid=foobar",
+        "created"=>"2016-02-01T15:53:41.000Z",
+        "updated"=>"2016-02-01T15:53:42.020Z",
+        "summary"=>"Awesome event",
+        "description"=>
+          "An example event with text. Pro tip: DateTimes are in RFC3339",
+        "creator"=>
+          {"email"=>
+            "blah-foobar@developer.gserviceaccount.com"},
+        "organizer"=>
+          {"email"=>calendar_id,
+            "displayName"=>"Huginn Location Log",
+            "self"=>true},
+        "start"=>{"dateTime"=>"2014-10-03T00:30:00+09:30"},
+        "end"=>{"dateTime"=>"2014-10-03T01:30:00+09:30"},
+        "iCalUID"=>"blah@google.com",
+        "sequence"=>0,
+        "reminders"=>{"useDefault"=>true}
+      }.to_json
+    end
 
-      @checker.receive([event1])
+    before do
+      fake_interface = Object.new
+      mock(GoogleCalendar).new(agent.options, Rails.logger) { fake_interface }
+      mock(fake_interface).publish_as(calendar_id, message) { stub!.response.stub!.body { response_body } }
+    end
 
-      expect(@checker.events.count).to eq(1)
+    describe 'when the calendar_id is in the options' do
+      it 'should publish any payload it receives' do
+        expect {
+          agent.receive([event])
+        }.to change { agent.events.count }.by(1)
+
+        expect(agent.events.last.payload).to eq({ "success" => true, "published_calendar_event" => JSON.parse(response_body), "agent_id" => event.agent_id, "event_id" => event.id })
+      end
+    end
+
+    describe 'with Liquid templating' do
+      it 'should allow Liquid in the calendar_id' do
+        agent.options['calendar_id'] = '{{ cal_id }}'
+        agent.save!
+
+        event.payload['cal_id'] = calendar_id
+        event.save!
+
+        agent.receive([event])
+
+        expect(agent.events.count).to eq(1)
+        expect(agent.events.last.payload).to eq({ "success" => true, "published_calendar_event" => JSON.parse(response_body), "agent_id" => event.agent_id, "event_id" => event.id })
+      end
     end
   end
 end


### PR DESCRIPTION
Should fix #1229.