### PR TITLE
Fix heroku documentation

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,8 +21,8 @@
                 <%= content_tag :pre do -%>
 heroku git:clone --app <%= content_tag :var, app_name %>
 cd <%= content_tag :var, app_name %>
-bundle
 cp .env.example .env
+bundle
 bin/setup_heroku
 <%- end %>
 

--- a/doc/heroku/install.md
+++ b/doc/heroku/install.md
@@ -15,7 +15,7 @@ If you still wish to use the Heroku free plan (which won't work very well), plea
 ## Instructions
 
 * Install the [Heroku Toolbelt](https://toolbelt.heroku.com/) and then run `heroku login`
-* Go into your huginn directory and run `bundle`
+* Go into your huginn directory and run `cp .env.example .env && bundle`
 * Now, run the magic setup wizard: `bin/setup_heroku`
 * That's it!
 * If you make changes, you can re-run `bin/setup_heroku`, or just do `git push heroku master`.


### PR DESCRIPTION
Since #1040 .env.example needs to be copied to .env before bundling

Maybe related to #1246 