### PR TITLE
#1272 Allow error codes, such as 404, to be considered successful

### DIFF
--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -181,8 +181,6 @@ module Agents
           else
             if consider_success.map(&:class).uniq != [Fixnum]
               errors.add(:base,"Please make sure to use only integer values for code")
-            else
-              @error_codes_considered_success = consider_success
             end
           end
         end
@@ -297,6 +295,7 @@ module Agents
       uri = Utils.normalize_uri(url)
       log "Fetching #{uri}"
       response = faraday.get(uri)
+
       raise "Failed: #{response.inspect}" unless consider_response_successful?(response)
 
       interpolation_context.stack {
@@ -379,7 +378,8 @@ module Agents
     private
     def consider_response_successful?(response)
       response.success? || begin
-        @error_codes_considered_success.present? && @error_codes_considered_success.include?(response.status)
+        consider_success = options["consider_http_error_success"]
+        consider_success.present? && consider_success.include?(response.status)
       end
     end
 

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -151,7 +151,7 @@ module Agents
       errors.add(:base, "either url, url_from_event, or data_from_event are required") unless options['url'].present? || options['url_from_event'].present? || options['data_from_event'].present?
       errors.add(:base, "expected_update_period_in_days is required") unless options['expected_update_period_in_days'].present?
       validate_extract_options!
-      validate_consider_http_success_option!
+      validate_http_success_codes!
 
       # Check for optional fields
       if options['mode'].present?
@@ -169,16 +169,14 @@ module Agents
       validate_web_request_options!
     end
 
-    def validate_consider_http_success_option!
+    def validate_http_success_codes!
       consider_success = options["http_success_codes"]
-      if consider_success != nil
+      if consider_success.present?
 
         if (consider_success.class != Array)
           errors.add(:http_success_codes, "must be an array and specify at least one status code")
         else
-          if consider_success.blank?
-            errors.add(:http_success_codes, "must not be empty")
-          elsif consider_success.uniq.count != consider_success.count
+          if consider_success.uniq.count != consider_success.count
             errors.add(:http_success_codes, "duplicate http code found")
           else
             if consider_success.any?{|e| e.to_s !~ /^\d+$/ }

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -40,6 +40,23 @@ describe Agents::WebsiteAgent do
         expect(@checker).not_to be_valid
       end
 
+      it 'should validate the consider_http_error_success fields' do
+        @checker.options['consider_http_error_success'] = [404]
+        expect(@checker).to be_valid
+
+        @checker.options['consider_http_error_success'] = [404, 404]
+        expect(@checker).not_to be_valid
+
+        @checker.options['consider_http_error_success'] = [404.0]
+        expect(@checker).not_to be_valid
+
+        @checker.options['consider_http_error_success'] = ["not_a_code"]
+        expect(@checker).not_to be_valid
+
+        @checker.options['consider_http_error_success'] = []
+        expect(@checker).not_to be_valid
+      end
+
       it "should validate uniqueness_look_back" do
         @checker.options['uniqueness_look_back'] = "nonsense"
         expect(@checker).not_to be_valid
@@ -166,6 +183,38 @@ describe Agents::WebsiteAgent do
           @checker.options = @valid_options
           @checker.check
         }.to change { Event.count }.by(1)
+      end
+    end
+
+    describe 'consider_http_error_success' do
+      it 'should allow scraping from a 404 result' do
+        json = {
+          'response' => {
+            'version' => 2,
+            'title' => "hello!"
+          }
+        }
+        zipped = ActiveSupport::Gzip.compress(json.to_json)
+        stub_request(:any, /gzip/).to_return(body: zipped, headers: { 'Content-Encoding' => 'gzip' }, status: 404)
+        site = {
+          'name' => "Some JSON Response",
+          'expected_update_period_in_days' => "2",
+          'type' => "json",
+          'url' => "http://gzip.com",
+          'mode' => 'on_change',
+          'consider_http_error_success': [404],
+          'extract' => {
+            'version' => { 'path' => 'response.version' },
+          },
+          # no unzip option
+        }
+        checker = Agents::WebsiteAgent.new(:name => "Weather Site", :options => site)
+        checker.user = users(:bob)
+        checker.save!
+
+        checker.check
+        event = Event.last
+        expect(event.payload['version']).to eq(2)
       end
     end
 

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -57,7 +57,13 @@ describe Agents::WebsiteAgent do
         expect(@checker).not_to be_valid
 
         @checker.options['http_success_codes'] = []
-        expect(@checker).not_to be_valid
+        expect(@checker).to be_valid
+
+        @checker.options['http_success_codes'] = ''
+        expect(@checker).to be_valid
+
+        @checker.options['http_success_codes'] = false
+        expect(@checker).to be_valid
       end
 
       it "should validate uniqueness_look_back" do

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -40,20 +40,23 @@ describe Agents::WebsiteAgent do
         expect(@checker).not_to be_valid
       end
 
-      it 'should validate the consider_http_error_success fields' do
-        @checker.options['consider_http_error_success'] = [404]
+      it 'should validate the http_success_codes fields' do
+        @checker.options['http_success_codes'] = [404]
         expect(@checker).to be_valid
 
-        @checker.options['consider_http_error_success'] = [404, 404]
+        @checker.options['http_success_codes'] = [404, 404]
         expect(@checker).not_to be_valid
 
-        @checker.options['consider_http_error_success'] = [404.0]
+        @checker.options['http_success_codes'] = [404, "422"]
+        expect(@checker).to be_valid
+
+        @checker.options['http_success_codes'] = [404.0]
         expect(@checker).not_to be_valid
 
-        @checker.options['consider_http_error_success'] = ["not_a_code"]
+        @checker.options['http_success_codes'] = ["not_a_code"]
         expect(@checker).not_to be_valid
 
-        @checker.options['consider_http_error_success'] = []
+        @checker.options['http_success_codes'] = []
         expect(@checker).not_to be_valid
       end
 
@@ -186,7 +189,7 @@ describe Agents::WebsiteAgent do
       end
     end
 
-    describe 'consider_http_error_success' do
+    describe 'http_success_codes' do
       it 'should allow scraping from a 404 result' do
         json = {
           'response' => {
@@ -202,7 +205,7 @@ describe Agents::WebsiteAgent do
           'type' => "json",
           'url' => "http://gzip.com",
           'mode' => 'on_change',
-          'consider_http_error_success' => [404],
+          'http_success_codes' => [404],
           'extract' => {
             'version' => { 'path' => 'response.version' },
           },

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -202,7 +202,7 @@ describe Agents::WebsiteAgent do
           'type' => "json",
           'url' => "http://gzip.com",
           'mode' => 'on_change',
-          'consider_http_error_success': [404],
+          'consider_http_error_success' => [404],
           'extract' => {
             'version' => { 'path' => 'response.version' },
           },


### PR DESCRIPTION
I've opened an issue earlier, https://github.com/cantino/huginn/issues/1272 , in which I was saying that I have a page with returns 404, but it contains the data I need. I've implemented a potential solution for the website agent, and some tests. Could you please have a look, and decide whether this would be something useful to have?