### PR TITLE
TwitterStreamAgent prevent connection in use and restart issues

### DIFF
--- a/app/concerns/long_runnable.rb
+++ b/app/concerns/long_runnable.rb
@@ -98,13 +98,15 @@ module LongRunnable
 
     def terminate_thread!
       if thread
-        thread.terminate
+        thread.instance_eval { ActiveRecord::Base.connection_pool.release_connection }
         thread.wakeup if thread.status == 'sleep'
+        thread.terminate
       end
     end
 
     def restart!
       without_alive_check do
+        puts "--> Restarting #{id} at #{Time.now} <--"
         stop!
         setup!(scheduler, mutex)
         run!

--- a/spec/concerns/long_runnable_spec.rb
+++ b/spec/concerns/long_runnable_spec.rb
@@ -118,6 +118,7 @@ describe LongRunnable do
         mock(@worker).stop!
         mock(@worker).setup!(@worker.scheduler, @worker.mutex)
         mock(@worker).run!
+        mock(@worker).puts(anything) { |text| expect(text).to match(/Restarting/) }
         @worker.restart!
       end
     end


### PR DESCRIPTION
Ensures the database connection is checked back in to the pool before restarting.
Restart TwitterStreamAgent outside of the Rufus::Scheduler work thread.

/cc @cantino 