### PR TITLE
Update README.md to use absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you are viewing this from the docker hub page the please follow the links to 
 
 Huginn is a system for building agents that perform automated tasks for you online.  They can read the web, watch for events, and take actions on your behalf.  Huginn's Agents create and consume events, propagating them along a directed graph.  Think of it as a hackable Yahoo! Pipes plus IFTTT on your own server.  You always know who has your data.  You do.
 
-![the origin of the name](doc/imgs/the-name.png)
+![the origin of the name](https://raw.githubusercontent.com/cantino/huginn/master/doc/imgs/the-name.png)
 
 #### Here are some of the things that you can do with Huginn:
 
@@ -43,21 +43,21 @@ Please checkout the [Huginn Introductory Screencast](http://vimeo.com/61976251)!
 
 And now, some example screenshots.  Below them are instructions to get you started.
 
-![Example list of agents](doc/imgs/your-agents.png)
+![Example list of agents](https://raw.githubusercontent.com/cantino/huginn/master/doc/imgs/your-agents.png)
 
-![Event flow diagram](doc/imgs/diagram.png)
+![Event flow diagram](https://raw.githubusercontent.com/cantino/huginn/master/doc/imgs/diagram.png)
 
-![Detecting peaks in Twitter](doc/imgs/peaks.png)
+![Detecting peaks in Twitter](https://raw.githubusercontent.com/cantino/huginn/master/doc/imgs/peaks.png)
 
-![Logging your location over time](doc/imgs/my-locations.png)
+![Logging your location over time](https://raw.githubusercontent.com/cantino/huginn/master/doc/imgs/my-locations.png)
 
-![Making a new agent](doc/imgs/new-agent.png)
+![Making a new agent](https://raw.githubusercontent.com/cantino/huginn/master/doc/imgs/new-agent.png)
 
 ## Getting Started
 
 ### Docker
 
-The quickest and easiest way to check out Huginn is to use the offical Docker image. Have a look at the [documentation](./doc/docker/install.md).
+The quickest and easiest way to check out Huginn is to use the offical Docker image. Have a look at the [documentation](https://github.com/cantino/huginn/blob/master/doc/docker/install.md).
 
 ### Local Installation
 
@@ -90,7 +90,7 @@ All agents have specs! Test all specs with `bundle exec rspec`, or test a specif
 
 ### Heroku
 
-Try Huginn on Heroku: [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy) (Takes a few minutes to setup. Read the [documentation](./doc/heroku/install.md) while you are waiting and be sure to click 'View it' after launch!)
+Try Huginn on Heroku: [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy) (Takes a few minutes to setup. Read the [documentation](https://github.com/cantino/huginn/blob/master/doc/heroku/install.md) while you are waiting and be sure to click 'View it' after launch!)
 
 Huginn works on the free version of Heroku [with significant limitations](https://github.com/cantino/huginn/blob/master/doc/heroku/install.md). For non-experimental use, we strongly recommend Heroku's cheapest paid plan or our Docker container.
 
@@ -98,7 +98,7 @@ Please see [the Huginn Wiki](https://github.com/cantino/huginn/wiki#deploying-hu
 
 ### Manual installation on any server
 
-Have a look at the [installation guide](./doc/manual/README.md).
+Have a look at the [installation guide](https://github.com/cantino/huginn/blob/master/doc/manual/README.md).
 
 ### Optional Setup
 


### PR DESCRIPTION
This will fix the broken images/links that appear when the README is used outside of [cantino/huginn](https://github.com/cantino/huginn) (e.g. the [Docker image page](https://hub.docker.com/r/cantino/huginn/)).