### PR TITLE
Avoid raising an error on missing credential, validation should catch it

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -299,9 +299,7 @@ module LiquidInterpolatable
       end
 
       def render(context)
-        credential = context.registers[:agent].credential(@credential_name)
-        raise "No user credential named '#{@credential_name}' defined" if credential.nil?
-        credential
+        context.registers[:agent].credential(@credential_name)
       end
     end
 

--- a/spec/support/shared_examples/liquid_interpolatable.rb
+++ b/spec/support/shared_examples/liquid_interpolatable.rb
@@ -91,10 +91,11 @@ shared_examples_for LiquidInterpolatable do
         expect(@checker.interpolate_string("{% credential aws_key %}", {})).to eq('2222222222-jane')
       end
 
-      it "should raise an exception for undefined credentials" do
+      it "should not raise an exception for undefined credentials" do
         expect {
-          @checker.interpolate_string("{% credential unknown %}", {})
-        }.to raise_error(/No user credential named/)
+          result = @checker.interpolate_string("{% credential unknown %}", {})
+          expect(result).to eq('')
+        }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Should help with https://github.com/virtadpt/exocortex-agents/issues/1.

The new outcome is:

<img width="996" alt="screen shot 2016-02-13 at 10 58 19 am" src="https://cloud.githubusercontent.com/assets/83835/13029439/258b2a52-d241-11e5-9fbb-0185cfbba512.png">

Still not great, but better than a 500 error.  @virtadpt, the Scenario description should probably have: "please create a credential called `weather_underground_api_key` before importing."