### PR TITLE
Allow From to be specified on email agents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,5 +184,5 @@ if_true(ENV['DATABASE_ADAPTER'].strip == 'postgresql') do
 end
 
 if_true(ENV['DATABASE_ADAPTER'].strip == 'mysql2') do
-  gem 'mysql2', '~> 0.3.16'
+  gem 'mysql2', '~> 0.3.20'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.3.16)
+    mysql2 (0.3.20)
     naught (1.0.0)
     nenv (0.2.0)
     net-ftp-list (3.2.8)
@@ -624,7 +624,7 @@ DEPENDENCIES
   mini_magick
   mqtt
   multi_xml
-  mysql2 (~> 0.3.16)
+  mysql2 (~> 0.3.20)
   net-ftp-list (~> 3.2.8)
   nokogiri (= 1.6.7.2)
   omniauth

--- a/app/mailers/system_mailer.rb
+++ b/app/mailers/system_mailer.rb
@@ -5,6 +5,9 @@ class SystemMailer < ActionMailer::Base
     @groups = options[:groups]
     @headline = options[:headline]
     @body = options[:body]
-    mail :to => options[:to], :subject => options[:subject]
+
+    mail_options = { to: options[:to], subject: options[:subject] }
+    mail_options[:from] = options[:from] if options[:from].present?
+    mail(mail_options)
   end
 end

--- a/app/models/agents/email_agent.rb
+++ b/app/models/agents/email_agent.rb
@@ -21,6 +21,8 @@ module Agents
       You can specify one or more `recipients` for the email, or skip the option in order to send the email to your
       account's default email address.
 
+      You can provide a `from` address for the email, or leave it blank to default to the value of `EMAIL_FROM_ADDRESS` (`#{ENV['EMAIL_FROM_ADDRESS']}`).
+
       Set `expected_receive_period_in_days` to the maximum amount of time that you'd expect to pass between Events being received by this Agent.
     MD
 
@@ -35,8 +37,15 @@ module Agents
     def receive(incoming_events)
       incoming_events.each do |event|
         recipients(event.payload).each do |recipient|
-          log "Sending digest mail to #{recipient} with event #{event.id}"
-          SystemMailer.send_message(:to => recipient, :subject => interpolated(event)['subject'], :headline => interpolated(event)['headline'], :body => interpolated(event)['body'], :groups => [present(event.payload)]).deliver_later
+          log "Sending mail to #{recipient} with event #{event.id}"
+          SystemMailer.send_message(
+            to: recipient,
+            from: interpolated(event)['from'],
+            subject: interpolated(event)['subject'],
+            headline: interpolated(event)['headline'],
+            body: interpolated(event)['body'],
+            groups: [present(event.payload)]
+          ).deliver_later
         end
       end
     end

--- a/app/models/agents/email_digest_agent.rb
+++ b/app/models/agents/email_digest_agent.rb
@@ -16,6 +16,8 @@ module Agents
       You can specify one or more `recipients` for the email, or skip the option in order to send the email to your
       account's default email address.
 
+      You can provide a `from` address for the email, or leave it blank to default to the value of `EMAIL_FROM_ADDRESS` (`#{ENV['EMAIL_FROM_ADDRESS']}`).
+
       Set `expected_receive_period_in_days` to the maximum amount of time that you'd expect to pass between Events being received by this Agent.
     MD
 
@@ -42,7 +44,13 @@ module Agents
         groups = self.memory['queue'].map { |payload| present(payload) }
         recipients.each do |recipient|
           log "Sending digest mail to #{recipient} with events [#{ids}]"
-          SystemMailer.send_message(:to => recipient, :subject => interpolated['subject'], :headline => interpolated['headline'], :groups => groups).deliver_later
+          SystemMailer.send_message(
+            to: recipient,
+            from: interpolated['from'],
+            subject: interpolated['subject'],
+            headline: interpolated['headline'],
+            groups: groups
+          ).deliver_later
         end
         self.memory['queue'] = []
         self.memory['events'] = []


### PR DESCRIPTION
Should fix #1307.

Note that if you're using Gmail, I think it'll still show your normal from (and add a `X-Google-Original-From` header instead) unless you add that from address as a valid sender on the account you use.