### PR TITLE
Revert "Add notice to README to make users aware of the docker hub issues"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-If you are viewing this from the docker hub page, then please follow the links to view the actual documentation for the [cantino/huginn](https://github.com/cantino/huginn/tree/master/docker/multi-process) or [cantino/huginn-single-process](https://github.com/cantino/huginn/tree/master/docker/single-process) image. Help us getting the bug fixed which is causing this inconvenience by commenting on [this issue](https://github.com/docker/hub-feedback/issues/467)
-
 ![Huginn](https://raw.github.com/cantino/huginn/master/media/huginn-logo.png "Your agents are standing by.")
 
 -----


### PR DESCRIPTION
This reverts commit 3b973395d2781f68683f0686e9c03c914c5b502c.

READMEs on docker hub for images with nested Docker files were fixed!

https://hub.docker.com/r/cantino/huginn/
https://hub.docker.com/r/cantino/huginn-single-process/

