### PR TITLE
Add json liquid filter to serialize data to a JSON string

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -220,6 +220,11 @@ module LiquidInterpolatable
       input.to_s.sub(Regexp.new(regex), unescape_replacement(replacement.to_s))
     end
 
+    # Serializes data as JSON
+    def json(input)
+      JSON.dump(input)
+    end
+
     private
 
     def logger

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -48,6 +48,16 @@ describe LiquidInterpolatable::Filters do
     end
   end
 
+  describe "json" do
+    let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
+
+    it 'serializes data to json' do
+      agent.interpolation_context['something'] = {foo: 'bar'}
+      agent.options['cleaned'] = '{{ something | json }}'
+      expect(agent.interpolated['cleaned']).to eq('{"foo":"bar"}')
+    end
+  end
+
   describe 'to_xpath' do
     before do
       def @filter.to_xpath_roundtrip(string)


### PR DESCRIPTION
Example: `{{ data | json}}` takes the object of the payloads data key and converts it to JSON