### PR TITLE
multi-process/README.md: postgres -> postgresql

### DIFF
--- a/docker/multi-process/README.md
+++ b/docker/multi-process/README.md
@@ -27,7 +27,7 @@ There is an exported docker volume of /var/lib/mysql to allow persistence of tha
 
 Additionally, the database variables may be overridden from the above as per the standard Huginn documentation:
 
-    DATABASE_ADAPTER #(must be either 'postgres' or 'mysql2')
+    DATABASE_ADAPTER #(must be either 'postgresql' or 'mysql2')
     DATABASE_HOST
     DATABASE_PORT
 


### PR DESCRIPTION
'postgres' should be 'postgresql'

```sh
case "${DATABASE_ADAPTER}" in
  mysql2) DATABASE_PORT=${DATABASE_PORT:-3306} ;;
  postgresql) DATABASE_PORT=${DATABASE_PORT:-5432} ;;
  *) echo "Unsupported database adapter. Available adapters are mysql2, and postgresql." && exit 1 ;;
esac
```
https://github.com/cantino/huginn/blob/767e010e4af47f3d335971c4340c19857aaa0bc8/docker/multi-process/scripts/init#L55