### PR TITLE
 Downcase header names in Events that PostAgent emits

### DIFF
--- a/db/migrate/20160405072512_post_agent_set_event_header_style.rb
+++ b/db/migrate/20160405072512_post_agent_set_event_header_style.rb
@@ -1,0 +1,11 @@
+class PostAgentSetEventHeaderStyle < ActiveRecord::Migration
+  def up
+    Agent.of_type("Agents::PostAgent").each do |post_agent|
+      if post_agent.send(:boolify, post_agent.options['emit_events']) &&
+         !post_agent.options.key?('event_headers_style')
+        post_agent.options['event_headers_style'] = 'raw'
+        post_agent.save!
+      end
+    end
+  end
+end

--- a/spec/models/agents/post_agent_spec.rb
+++ b/spec/models/agents/post_agent_spec.rb
@@ -52,7 +52,7 @@ describe Agents::PostAgent do
           raise "unexpected Content-Type: #{content_type}"
         end
       end
-      { status: 200, body: "<html>a webpage!</html>", headers: { 'Content-Type' => 'text/html' } }
+      { status: 200, body: "<html>a webpage!</html>", headers: { 'Content-type' => 'text/html' } }
     }
   end
 
@@ -226,9 +226,27 @@ describe Agents::PostAgent do
           expect(@checker.events.last.payload['body']).to eq '<html>a webpage!</html>'
         end
 
-        it "emits the response headers" do
+        it "emits the response headers capitalized by default" do
           @checker.check
           expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'text/html' })
+        end
+
+        it "emits the response headers capitalized" do
+          @checker.options['event_headers_style'] = 'capitalized'
+          @checker.check
+          expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'text/html' })
+        end
+
+        it "emits the response headers downcased" do
+          @checker.options['event_headers_style'] = 'downcased'
+          @checker.check
+          expect(@checker.events.last.payload['headers']).to eq({ 'content-type' => 'text/html' })
+        end
+
+        it "emits the response headers snakecased" do
+          @checker.options['event_headers_style'] = 'snakecased'
+          @checker.check
+          expect(@checker.events.last.payload['headers']).to eq({ 'content_type' => 'text/html' })
         end
       end
     end


### PR DESCRIPTION
HTTP header names are case-insensitive and they may vary depending on FARADAY_HTTP_BACKEND, so downcase them for the ease of using.

As you can see in [this failure](https://travis-ci.org/cantino/huginn/builds/114744672), the net_http backend downcases response header names whereas the typhoeus backend does not.