### PR TITLE
Increase capybara default_max_wait_time to 60 seconds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'protected_attributes', '~>1.0.8' # This must be loaded before some other ge
 gem 'ace-rails-ap', '~> 2.0.1'
 gem 'bootstrap-kaminari-views', '~> 0.0.3'
 gem 'bundler', '>= 1.5.0'
-gem 'coffee-rails', '~> 4.1.0'
+gem 'coffee-rails', '~> 4.1.1'
 gem 'daemons', '~> 1.1.9'
 gem 'delayed_job', '~> 4.1.0'
 gem 'delayed_job_active_record', github: 'collectiveidea/delayed_job_active_record', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,13 +144,13 @@ GEM
     chronic (0.10.2)
     cliver (0.3.2)
     coderay (1.1.0)
-    coffee-rails (4.1.0)
+    coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
-    coffee-script (2.3.0)
+      railties (>= 4.0.0, < 5.1.x)
+    coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1)
+    coffee-script-source (1.10.0)
     colorize (0.7.7)
     concurrent-ruby (1.0.1)
     cookiejar (0.3.2)
@@ -585,7 +585,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1.4)
   capistrano-rails (~> 1.1)
   capybara-select2
-  coffee-rails (~> 4.1.0)
+  coffee-rails (~> 4.1.1)
   coveralls
   daemons (~> 1.1.9)
   delayed_job (~> 4.1.0)

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -2,7 +2,13 @@ require 'rails_helper'
 require 'capybara/rails'
 require 'capybara/poltergeist'
 require 'capybara-select2'
+
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, timeout: 60)
+end
+
 Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 60
 
 RSpec.configure do |config|
   config.include Warden::Test::Helpers


### PR DESCRIPTION
The default wait time of 2 seconds produced false positives on slow test runners.