### PR TITLE
Add column with default sort to prioritize new Agents in the index view

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -4,7 +4,7 @@ class AgentsController < ApplicationController
   include SortableTable
 
   def index
-    set_table_sort sorts: %w[name last_check_at last_event_at last_receive_at], default: { name: :asc }
+    set_table_sort sorts: %w[name created_at last_check_at last_event_at last_receive_at], default: { created_at: :desc }
 
     @agents = current_user.agents.preload(:scenarios, :controllers).reorder(table_sort).page(params[:page])
 

--- a/app/views/agents/_table.html.erb
+++ b/app/views/agents/_table.html.erb
@@ -2,6 +2,7 @@
   <table class='table table-striped'>
     <tr>
       <th><%= sortable_column 'name', 'asc' %></th>
+      <th><%= sortable_column 'created_at', 'desc', name: 'Age' %></th>
       <th>Schedule</th>
       <th><%= sortable_column 'last_check_at', name: 'Last Check' %></th>
       <th><%= sortable_column 'last_event_at', name: 'Last Event Out' %></th>
@@ -22,6 +23,9 @@
               <%= scenario_links(agent) %>
             </span>
           <% end %>
+        </td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <%= time_ago_in_words agent.created_at %>
         </td>
         <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
           <% if agent.can_be_scheduled? %>


### PR DESCRIPTION
Add an age column to the Agent list view and default it on, with descending order.  Seems more useful than name by default?

<img width="1203" alt="screen shot 2016-03-13 at 1 27 14 pm" src="https://cloud.githubusercontent.com/assets/83835/13731138/6e3955f4-e91f-11e5-80b8-0757edf261d3.png">
