### PR TITLE
Add initializer which sets the TZ environment variable

### DIFF
--- a/config/initializers/timezone.rb
+++ b/config/initializers/timezone.rb
@@ -1,0 +1,2 @@
+# Set the timezone for the JavascriptAgent (libv8 only relies on the TZ variable)
+ENV['TZ'] = Time.zone.tzinfo.canonical_identifier


### PR DESCRIPTION
This properly propagates the configured TIMEZONE to the system TZ variable which is used by libv8 in the JavascriptAgent to access the current time.

#1355 