### PR TITLE
Make DJ logs visible when running in foreground

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -5,6 +5,7 @@ Delayed::Worker.read_ahead = 5
 Delayed::Worker.default_priority = 10
 Delayed::Worker.delay_jobs = !Rails.env.test?
 Delayed::Worker.sleep_delay = (ENV['DELAYED_JOB_SLEEP_DELAY'].presence || 10).to_f
+Delayed::Worker.logger = Rails.logger
 
 # Delayed::Worker.logger = Logger.new(Rails.root.join('log', 'delayed_job.log'))
 # Delayed::Worker.logger.level = Logger::DEBUG


### PR DESCRIPTION
I'm running `bundle exec foreman start` to fire off both worker and web processes. I see the web logs, but I don't see the worker logs. This change combines the logs into one place which jives nicely with 12-factor platforms.