### PR TITLE
Menu actions on more screens

### DIFF
--- a/app/views/agents/_mini_action_menu.html.erb
+++ b/app/views/agents/_mini_action_menu.html.erb
@@ -1,0 +1,7 @@
+
+<div class="btn-group">
+  <button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown">
+    <span class="caret"></span>
+  </button>
+  <%= render 'agents/action_menu', agent: agent, return_to: (defined?(return_to) && return_to) || request.path %>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -3,7 +3,11 @@
     <div class='col-md-12'>
       <div class="page-header">
         <h2>
-          Your Events <%= @agent && "from #{@agent.name}" %>
+          Your Events
+          <% if @agent %>
+            from <%= @agent.name %>
+            <%= render 'agents/mini_action_menu', agent: @agent, return_to:   request.path %>
+          <% end %>
         </h2>
       </div>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,7 +2,15 @@
   <div class='row'>
     <div class='col-md-12'>
       <div class="page-header">
-        <h2>Event from <%= @event.agent.name %></h2>
+        <h2>
+          Event from <%= @event.agent.name %>
+          <div class="btn-group">
+            <button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown">
+              <span class="caret"></span>
+            </button>
+            <%= render 'agents/action_menu', agent: @event.agent, return_to: (defined?(return_to) && return_to) || request.path %>
+          </div>
+        </h2>
       </div>
 
       <p>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,12 +4,7 @@
       <div class="page-header">
         <h2>
           Event from <%= @event.agent.name %>
-          <div class="btn-group">
-            <button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown">
-              <span class="caret"></span>
-            </button>
-            <%= render 'agents/action_menu', agent: @event.agent, return_to: (defined?(return_to) && return_to) || request.path %>
-          </div>
+          <%= render 'agents/mini_action_menu', agent: @event.agent, return_to: event_path(@event) %>
         </h2>
       </div>
 


### PR DESCRIPTION
Usability would be greatly improved if the "actions" menu were visible whenever possible.

What do you think?
Here's an example:

![](http://i.imgur.com/VBQe540.png)

![](http://i.imgur.com/1BMI3XQ.png)