### PR TITLE
Simplify the log format for Dry Run

### DIFF
--- a/spec/concerns/dry_runnable_spec.rb
+++ b/spec/concerns/dry_runnable_spec.rb
@@ -70,7 +70,7 @@ describe DryRunnable do
       [@agent.memory, counts]
     }
 
-    expect(results[:log]).to match(/\AE, .+ ERROR -- : Exception during dry-run. SandboxedAgent does not support dry-run: /)
+    expect(results[:log]).to match(/\A\[\d\d:\d\d:\d\d\] INFO -- : Dry Run failed\n\[\d\d:\d\d:\d\d\] ERROR -- : Exception during dry-run. SandboxedAgent does not support dry-run: /)
     expect(results[:events]).to eq([])
     expect(results[:memory]).to eq({})
   end
@@ -86,7 +86,7 @@ describe DryRunnable do
         [@agent.memory, counts]
       }
 
-      expect(results[:log]).to match(/\AI, .+ INFO -- : Logging\nE, .+ ERROR -- : Recording error\n/)
+      expect(results[:log]).to match(/\A\[\d\d:\d\d:\d\d\] INFO -- : Dry Run started\n\[\d\d:\d\d:\d\d\] INFO -- : Logging\n\[\d\d:\d\d:\d\d\] ERROR -- : Recording error\n/)
       expect(results[:events]).to eq([{ 'test' => 'foo' }, { 'test' => 'bar' }])
       expect(results[:memory]).to eq({ 'last_status' => 'ok', 'dry_run' => true })
     end
@@ -101,7 +101,7 @@ describe DryRunnable do
         [@agent.memory, counts]
       }
 
-      expect(results[:log]).to match(/\AI, .+ INFO -- : Logging\nE, .+ ERROR -- : Recording error\n/)
+      expect(results[:log]).to match(/\A\[\d\d:\d\d:\d\d\] INFO -- : Dry Run started\n\[\d\d:\d\d:\d\d\] INFO -- : Logging\n\[\d\d:\d\d:\d\d\] ERROR -- : Recording error\n/)
       expect(results[:events]).to eq([{ 'test' => 'superfoo' }, { 'test' => 'superbar' }])
       expect(results[:memory]).to eq({ 'last_status' => 'ok', 'dry_run' => true })
     end

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -406,7 +406,7 @@ describe AgentsController do
         [users(:bob).agents.count, users(:bob).events.count, users(:bob).logs.count, agent.name, agent.updated_at]
       }
       json = JSON.parse(response.body)
-      expect(json['log']).to match(/^I, .* : Fetching #{Regexp.quote(url_from_event)}$/)
+      expect(json['log']).to match(/^\[\d\d:\d\d:\d\d\] INFO -- : Fetching #{Regexp.quote(url_from_event)}$/)
     end
   end
 


### PR DESCRIPTION
- Omit the severity initial and progname
- Show the elapsed time in HH:MM:SS instead of full date-time
![2016-03-29 18 56 22](https://cloud.githubusercontent.com/assets/10236/14104409/07212306-f5e0-11e5-8a05-cb41efe1566d.png)
