### PR TITLE
escape the otherwise omitted auth_token within the telegram agents getUpdates address

### DIFF
--- a/app/models/agents/telegram_agent.rb
+++ b/app/models/agents/telegram_agent.rb
@@ -20,7 +20,7 @@ module Agents
 
       1. Obtain an `auth_token` by [creating a new bot](https://telegram.me/botfather).
       2. Send a private message to your bot by visiting https://telegram.me/YourHuginnBot
-      3. Obtain your private `chat_id` from the recently started conversation by visiting https://api.telegram.org/bot<auth_token>/getUpdates
+      3. Obtain your private `chat_id` from the recently started conversation by visiting https://api.telegram.org/bot`<auth_token>`/getUpdates
     MD
 
     def default_options


### PR DESCRIPTION
@Pcsl commented in #1381 that step 3 of the telegram agents setup description is confusing. As I figured out now, that is because markdown omitted the `<auth_token>` from the url. I marked it as code now and it gets displayed as intended: 
<img width="562" alt="screen shot 2016-04-01 at 09 02 06" src="https://cloud.githubusercontent.com/assets/3586316/14200012/75aaef32-f7e8-11e5-8c97-95303b819f45.png">
