### PR TITLE
sms.messages is being deprecated from twilio

### DIFF
--- a/app/models/agents/twilio_agent.rb
+++ b/app/models/agents/twilio_agent.rb
@@ -66,7 +66,7 @@ module Agents
     end
 
     def send_message(message)
-      client.account.sms.messages.create :from => interpolated['sender_cell'],
+      client.account.messages.create :from => interpolated['sender_cell'],
                                          :to => interpolated['receiver_cell'],
                                          :body => message
     end

--- a/spec/models/agents/twilio_agent_spec.rb
+++ b/spec/models/agents/twilio_agent_spec.rb
@@ -20,8 +20,8 @@ describe Agents::TwilioAgent do
     @event.save!
 
     @sent_messages = []
-    stub.any_instance_of(Agents::TwilioAgent).send_message { |message| @sent_messages << message}
-    stub.any_instance_of(Agents::TwilioAgent).make_call {}
+    stub.any_instance_of(Twilio::REST::Messages).create { |message| @sent_messages << message[:body]}
+    stub.any_instance_of(Twilio::REST::Calls).create
   end
 
   describe '#receive' do
@@ -51,7 +51,6 @@ describe Agents::TwilioAgent do
       @checker.receive([@event])
       expect(@checker.memory[:pending_calls]).not_to eq({})
     end
-
   end
 
   describe '#working?' do


### PR DESCRIPTION
Instead, you're supposed to just call `messages`