### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,5 @@ deployment/cookbooks
 manifest.yml
 config/unicorn.rb
 db/schema.rb
+nitrous-post-create.sh
+nitrous.json

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ If you need more detailed instructions, see the [Novice setup guide][novice-setu
 [wiki]: https://github.com/cantino/huginn/wiki
 [novice-setup-guide]: https://github.com/cantino/huginn/wiki/Novice-setup-guide
 
+### Nitrous Quickstart
+
+You can quickly create a free development environment for this Huginn project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Huginn via `Run > Start Huginn` and access your site via `Preview > 3000`.
+
 ### Develop
 
 All agents have specs! And there's also acceptance tests that simulate running Huginn in a headless browser. 

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+rm -rf ~/code/example
+
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+export DEBIAN_FRONTEND=noninteractive
+
+sudo apt-get update
+sudo -E apt-get -q -y install mysql-server
+sudo apt-get -y install libmysqlclient-dev pwgen
+sudo apt-get clean
+
+cp .env.example .env
+
+MYSQL_PASSWORD=`pwgen -1`
+mysql -u root -e "CREATE USER 'huginn'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';"
+mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'huginn'@'localhost';"
+sed -i 's/DATABASE_USERNAME=.*/DATABASE_USERNAME=huginn/g' .env
+sed -i "s/DATABASE_PASSWORD=.*/DATABASE_PASSWORD=\"$MYSQL_PASSWORD\"/g" .env
+
+APP_SECRET_TOKEN=`pwgen 24 -1`
+sed -i "s/APP_SECRET_TOKEN=.*/APP_SECRET_TOKEN=$APP_SECRET_TOKEN/g" .env
+
+npm install -g phantomjs-prebuilt
+gem install bundler
+bundle install
+bundle exec rake db:create
+bundle exec rake db:migrate
+bundle exec rake db:seed
+
+cat >> ~/code/huginn/README.nitrous.md <<EOT
+# Setup
+
+Welcome to your Huginn project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Huginn via "Run > Start Huginn" and wait for 30 seconds for the server to be started.
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".
+EOT

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,9 @@
+{
+  "template": "rails",
+  "ports": [3000],
+  "name": "Huginn",
+  "description": "Build agents that monitor and act on your behalf. Your agents are standing by!",
+  "scripts": {
+    "Start Huginn": "cd ~/code/huginn && bundle exec foreman start"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.