### PR TITLE
Do not run/enqueue event propagation when a AgentPropagateJob is already enqueued

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -113,11 +113,15 @@ class AgentsController < ApplicationController
   end
 
   def propagate
-    details = Agent.receive! # Eventually this should probably be scoped to the current_user.
-
     respond_to do |format|
-      format.html { redirect_back "Queued propagation calls for #{details[:event_count]} event(s) on #{details[:agent_count]} agent(s)" }
-      format.json { head :ok }
+      if AgentPropagateJob.can_enqueue?
+        details = Agent.receive! # Eventually this should probably be scoped to the current_user.
+        format.html { redirect_back "Queued propagation calls for #{details[:event_count]} event(s) on #{details[:agent_count]} agent(s)" }
+        format.json { head :ok }
+      else
+        format.html { redirect_back "Event propagation is already scheduled to run." }
+        format.json { head :locked }
+      end
     end
   end
 

--- a/app/jobs/agent_propagate_job.rb
+++ b/app/jobs/agent_propagate_job.rb
@@ -1,7 +1,19 @@
 class AgentPropagateJob < ActiveJob::Base
-  queue_as :default
+  queue_as :propagation
 
   def perform
     Agent.receive!
+  end
+
+  def self.can_enqueue?
+    if Rails.configuration.active_job.queue_adapter == :delayed_job &&
+       Delayed::Job.where(failed_at: nil, queue: 'propagation').count > 0
+      return false
+    elsif Rails.configuration.active_job.queue_adapter == :resque &&
+          (Resque.size('propagation') > 0 ||
+           Resque.workers.select { |w| w.job && w.job['queue'] && w.job['queue']['propagation'] }.count > 0)
+      return false
+    end
+    true
   end
 end

--- a/lib/huginn_scheduler.rb
+++ b/lib/huginn_scheduler.rb
@@ -155,6 +155,7 @@ class HuginnScheduler < LongRunnable::Worker
 
   def propagate!
     with_mutex do
+      return unless AgentPropagateJob.can_enqueue?
       puts "Queuing event propagation"
       AgentPropagateJob.perform_later
     end

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -68,10 +68,19 @@ describe AgentsController do
   end
 
   describe "POST propagate" do
-    it "runs event propagation for all Agents" do
+    before(:each) do
       sign_in users(:bob)
+    end
+
+    it "runs event propagation for all Agents" do
       mock.proxy(Agent).receive!
       post :propagate
+    end
+
+    it "does not run the propagation when a job is already enqueued" do
+      mock(AgentPropagateJob).can_enqueue? { false }
+      post :propagate
+      expect(flash[:notice]).to eq('Event propagation is already scheduled to run.')
     end
   end
 

--- a/spec/jobs/agent_propagate_job_spec.rb
+++ b/spec/jobs/agent_propagate_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe AgentPropagateJob do
+  it "calls Agent.receive! when run" do
+    mock(Agent).receive!
+    AgentPropagateJob.new.perform
+  end
+
+  context "#can_enqueue?" do
+    it "is truthy when no propagation job is queued" do
+      expect(AgentPropagateJob.can_enqueue?).to be_truthy
+    end
+
+    it "is falsy when a progation job is queued" do
+      Delayed::Job.create!(queue: 'propagation')
+      expect(AgentPropagateJob.can_enqueue?).to be_falsy
+    end
+
+    it "is truthy when a enqueued progation job failed" do
+      Delayed::Job.create!(queue: 'propagation', failed_at: Time.now - 1.minute)
+      expect(AgentPropagateJob.can_enqueue?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Fixes the creation of duplicated events caused by Agent.receive! running multiple times concurrently.

#1412