### PR TITLE
validate agent option json on form submit

### DIFF
--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -4,6 +4,15 @@ class @AgentEditPage
     @showCorrectRegionsOnStartup()
     $("form.agent-form").on "submit", => @updateFromEditors()
 
+    # Validate agents_options Json on form submit
+    $('form.agent-form').submit (e) ->
+      if $('textarea#agent_options').length
+        try
+          JSON.parse $('#agent_options').val()
+        catch err
+          e.preventDefault()
+          alert 'Sorry, there appears to be an error in your JSON input. Please fix it before continuing.'
+
     $("#agent_name").each ->
       # Select the number suffix if this is a cloned agent.
       if matches = this.value.match(/ \(\d+\)$/)

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -14,6 +14,7 @@ Capybara.default_max_wait_time = CAPYBARA_TIMEOUT
 
 RSpec.configure do |config|
   config.include Warden::Test::Helpers
+  config.include AlertConfirmer, type: :feature
   config.before :suite do
     Warden.test_mode!
   end

--- a/spec/features/create_an_agent_spec.rb
+++ b/spec/features/create_an_agent_spec.rb
@@ -13,4 +13,21 @@ describe "Creating a new agent", js: true do
 
     expect(page).to have_text("Test Trigger Agent")
   end
+
+  it "creates an alert if a new agent with invalid json is submitted" do
+    login_as(users(:bob))
+    visit "/"
+    page.find("a", text: "Agents").trigger(:mouseover)
+    click_on("New Agent")
+
+    select2("Trigger Agent", from: "Type")
+    fill_in(:agent_name, with: "Test Trigger Agent")
+    click_on("Toggle View")
+
+    fill_in(:agent_options, with: '{
+      "expected_receive_period_in_days": "2"
+      "keep_event": "false"
+    }')
+    expect(get_alert_text_from { click_on "Save" }).to have_text("Sorry, there appears to be an error in your JSON input. Please fix it before continuing.")
+  end
 end

--- a/spec/features/edit_an_agent_spec.rb
+++ b/spec/features/edit_an_agent_spec.rb
@@ -1,0 +1,15 @@
+require 'capybara_helper'
+
+describe "Editing an agent", js: true do
+  it "creates an alert if a agent with invalid json is submitted" do
+    login_as(users(:bob))
+    visit("/agents/#{agents(:bob_website_agent).id}/edit")
+    click_on("Toggle View")
+
+    fill_in(:agent_options, with: '{
+      "expected_receive_period_in_days": "2"
+      "keep_event": "false"
+    }')
+    expect(get_alert_text_from { click_on "Save" }).to have_text("Sorry, there appears to be an error in your JSON input. Please fix it before continuing.")
+  end
+end

--- a/spec/support/alert_confirmer.rb
+++ b/spec/support/alert_confirmer.rb
@@ -1,0 +1,53 @@
+module AlertConfirmer
+  def reject_confirm_from &block
+    handle_js_modal 'confirm', false, &block
+  end
+
+  def accept_confirm_from &block
+    handle_js_modal 'confirm', true, &block
+  end
+
+  def accept_alert_from &block
+    handle_js_modal 'alert', true, &block
+  end
+
+  def get_alert_text_from &block
+    handle_js_modal 'alert', true, true, &block
+    get_modal_text 'alert'
+  end
+
+  def get_modal_text(name)
+    page.evaluate_script "window.#{name}Msg;"
+  end
+
+  private
+
+  def handle_js_modal name, return_val, wait_for_call = false, &block
+    modal_called = "window.#{name}.called"
+    page.execute_script "
+    window.original_#{name}_function = window.#{name};
+    window.#{name} = function(msg) { window.#{name}Msg = msg; window.#{name}.called = true; return #{!!return_val}; };
+    #{modal_called} = false;
+    window.#{name}Msg = null;"
+
+    block.call
+
+    if wait_for_call
+      timed_out = false
+      timeout_after = Time.now + Capybara.default_max_wait_time
+      loop do
+        if page.evaluate_script(modal_called).nil?
+          raise 'appears that page has changed since this method has been called, please assert on page before calling this'
+        end
+
+        break if page.evaluate_script(modal_called) ||
+          (timed_out = Time.now > timeout_after)
+
+        sleep 0.001
+      end
+      raise "#{name} should have been called" if timed_out
+    end
+  ensure
+    page.execute_script "window.#{name} = window.original_#{name}_function"
+  end
+end


### PR DESCRIPTION
Hi 
when i tried to save invalid json for the agent_options my changes got lost. I realized that i could validate my json by using the editor toggle. 
The PR adds the same behaviour for the form submit if the agent_options texarea is present. 