### PR TITLE
fix for mqtt publish

### DIFF
--- a/app/models/agents/mqtt_agent.rb
+++ b/app/models/agents/mqtt_agent.rb
@@ -109,7 +109,7 @@ module Agents
     def receive(incoming_events)
       mqtt_client.connect do |c|
         incoming_events.each do |event|
-          c.publish(interpolated(event)['topic'], event.payload)
+          c.publish(interpolated(event)['topic'], event.payload['message'])
         end
       end
     end


### PR DESCRIPTION
this changes the event to event payload so that you can properly publish events
#1274  bug fix