### PR TITLE
Add multi stream support to gap detector

### DIFF
--- a/app/models/agents/gap_detector_agent.rb
+++ b/app/models/agents/gap_detector_agent.rb
@@ -8,6 +8,10 @@ module Agents
       The `value_path` value is a [JSONPath](http://goessner.net/articles/JsonPath/) to a value of interest. If either
       this value is empty, or no Events are received, during `window_duration_in_days`, an Event will be created with
       a payload of `message`.
+
+      The `stream_path` value is a [JSONPath](http://goessner.net/articles/JsonPath/) to a value in the event that will
+      be used to as a stream differentiator.  If `stream_path` is set to "color" and your event has a "color" in the
+      payload, this agent will watch for a gap in the stream for each value of color that has been seen.
     MD
 
     event_description <<-MD
@@ -42,12 +46,14 @@ module Agents
 
     def receive(incoming_events)
       incoming_events.sort_by(&:created_at).each do |event|
-        memory['newest_event_created_at'] ||= 0
-
         if !interpolated['value_path'].present? || Utils.value_at(event.payload, interpolated['value_path']).present?
-          if event.created_at.to_i > memory['newest_event_created_at']
-            memory['newest_event_created_at'] = event.created_at.to_i
-            memory.delete('alerted_at')
+          if stream_path
+            @stream = Utils.value_at(event.payload, stream_path)
+            next unless @stream
+          end
+          if event.created_at.to_i > newest_event_created_at
+            self.newest_event_created_at = event.created_at.to_i
+            clear_alerted_at
           end
         end
       end
@@ -55,13 +61,66 @@ module Agents
 
     def check
       window = interpolated['window_duration_in_days'].to_f.days.ago
-      if memory['newest_event_created_at'].present? && Time.at(memory['newest_event_created_at']) < window
-        unless memory['alerted_at']
-          memory['alerted_at'] = Time.now.to_i
-          create_event payload: { message: interpolated['message'],
-                                  gap_started_at: memory['newest_event_created_at'] }
+      if stream_path
+        memory.each_key do |stream|
+          next unless memory[stream].is_a? Hash
+          next unless memory[stream].has_key? 'newest_event_created_at'
+          @stream = stream
+          check_stream(window)
+        end
+      else
+        check_stream(window)
+      end
+    end
+
+    private
+
+    def check_stream(window)
+      window = interpolated['window_duration_in_days'].to_f.days.ago
+      if newest_event_created_at? && Time.at(newest_event_created_at) < window
+        unless alerted_at
+          self.alerted_at = Time.now.to_i
+          event_payload = { message: interpolated['message'],
+                            gap_started_at: newest_event_created_at }
+          event_payload.merge!({ stream_path => @stream }) if stream_path
+          create_event payload: event_payload
         end
       end
     end
+
+    def newest_event_created_at?
+      event_storage['newest_event_created_at'].present?
+    end
+
+    def newest_event_created_at
+      event_storage['newest_event_created_at'] || 0
+    end
+
+    def newest_event_created_at=(value)
+      event_storage['newest_event_created_at'] = value
+    end
+
+    def alerted_at
+      event_storage['alerted_at']
+    end
+
+    def alerted_at=(value)
+      event_storage['alerted_at'] = value
+    end
+
+    def clear_alerted_at
+      event_storage.delete('alerted_at')
+    end
+
+    def event_storage
+      return memory unless @stream_path
+      memory[@stream] = {} unless memory.has_key?(@stream)
+      memory[@stream]
+    end
+
+    def stream_path
+      @stream_path ||= interpolated['stream_path']
+    end
+
   end
 end

--- a/spec/models/agents/gap_detector_agent_spec.rb
+++ b/spec/models/agents/gap_detector_agent_spec.rb
@@ -44,69 +44,142 @@ describe Agents::GapDetectorAgent do
   end
 
   describe '#receive' do
-    it 'records the event if it has a created_at newer than the last seen' do
-      agent.receive([events(:bob_website_agent_event)])
-      expect(agent.memory['newest_event_created_at']).to eq events(:bob_website_agent_event).created_at.to_i
-
-      events(:bob_website_agent_event).created_at = 2.days.ago
-
-      expect {
+    context 'single stream' do
+      it 'records the event if it has a created_at newer than the last seen' do
         agent.receive([events(:bob_website_agent_event)])
-      }.to_not change { agent.memory['newest_event_created_at'] }
+        expect(agent.memory['newest_event_created_at']).to eq events(:bob_website_agent_event).created_at.to_i
 
-      events(:bob_website_agent_event).created_at = 2.days.from_now
+        events(:bob_website_agent_event).created_at = 2.days.ago
 
-      expect {
+        expect {
+          agent.receive([events(:bob_website_agent_event)])
+        }.to_not change { agent.memory['newest_event_created_at'] }
+
+        events(:bob_website_agent_event).created_at = 2.days.from_now
+
+        expect {
+          agent.receive([events(:bob_website_agent_event)])
+        }.to change { agent.memory['newest_event_created_at'] }.to(events(:bob_website_agent_event).created_at.to_i)
+      end
+
+      it 'ignores the event if value_path is present and the value at the path is blank' do
+        agent.options['value_path'] = 'title'
         agent.receive([events(:bob_website_agent_event)])
-      }.to change { agent.memory['newest_event_created_at'] }.to(events(:bob_website_agent_event).created_at.to_i)
+        expect(agent.memory['newest_event_created_at']).to eq events(:bob_website_agent_event).created_at.to_i
+
+        events(:bob_website_agent_event).created_at = 2.days.from_now
+        events(:bob_website_agent_event).payload['title'] = ''
+
+        expect {
+          agent.receive([events(:bob_website_agent_event)])
+        }.to_not change { agent.memory['newest_event_created_at'] }
+
+        events(:bob_website_agent_event).payload['title'] = 'present!'
+
+        expect {
+          agent.receive([events(:bob_website_agent_event)])
+        }.to change { agent.memory['newest_event_created_at'] }.to(events(:bob_website_agent_event).created_at.to_i)
+      end
+
+      it 'clears any previous alert' do
+        agent.memory['alerted_at'] = 2.days.ago.to_i
+        agent.receive([events(:bob_website_agent_event)])
+        expect(agent.memory).to_not have_key('alerted_at')
+      end
     end
 
-    it 'ignores the event if value_path is present and the value at the path is blank' do
-      agent.options['value_path'] = 'title'
-      agent.receive([events(:bob_website_agent_event)])
-      expect(agent.memory['newest_event_created_at']).to eq events(:bob_website_agent_event).created_at.to_i
+    context 'multi stream' do
+      it 'records the event for the specific stream' do
+        agent.options["stream_path"] = "my_option"
+        event = events(:bob_website_agent_event)
+        event.payload["my_option"] = "stream1"
+        agent.receive([event])
+        expect(agent.memory['stream1']['newest_event_created_at']).to eq event.created_at.to_i
 
-      events(:bob_website_agent_event).created_at = 2.days.from_now
-      events(:bob_website_agent_event).payload['title'] = ''
+        event.created_at = 2.days.ago
 
-      expect {
-        agent.receive([events(:bob_website_agent_event)])
-      }.to_not change { agent.memory['newest_event_created_at'] }
+        expect {
+          agent.receive([events(:bob_website_agent_event)])
+        }.to_not change { agent.memory['stream1']['newest_event_created_at'] }
 
-      events(:bob_website_agent_event).payload['title'] = 'present!'
+        event.created_at = 2.days.from_now
 
-      expect {
-        agent.receive([events(:bob_website_agent_event)])
-      }.to change { agent.memory['newest_event_created_at'] }.to(events(:bob_website_agent_event).created_at.to_i)
-    end
+        expect {
+          agent.receive([events(:bob_website_agent_event)])
+        }.to change { agent.memory['stream1']['newest_event_created_at'] }.to(event.created_at.to_i)
+      end
 
-    it 'clears any previous alert' do
-      agent.memory['alerted_at'] = 2.days.ago.to_i
-      agent.receive([events(:bob_website_agent_event)])
-      expect(agent.memory).to_not have_key('alerted_at')
+      it 'clears any previous alert' do
+        agent.options["stream_path"] = "my_option"
+        event = events(:bob_website_agent_event)
+        event.payload["my_option"] = "stream1"
+        agent.memory['stream1'] = { 'alerted_at' => 2.days.ago.to_i }
+        agent.receive([event])
+        expect(agent.memory['stream1']).to_not have_key('alerted_at')
+      end
     end
   end
 
   describe '#check' do
-    it 'alerts once if no data has been received during window_duration_in_days' do
-      agent.memory['newest_event_created_at'] = 1.days.ago.to_i
+    context 'single stream' do
+      it 'alerts once if no data has been received during window_duration_in_days' do
+        agent.memory['newest_event_created_at'] = 1.days.ago.to_i
 
-      expect {
-        agent.check
-      }.to_not change { agent.events.count }
+        expect {
+          agent.check
+        }.to_not change { agent.events.count }
 
-      agent.memory['newest_event_created_at'] = 3.days.ago.to_i
+        agent.memory['newest_event_created_at'] = 3.days.ago.to_i
 
-      expect {
-        agent.check
-      }.to change { agent.events.count }.by(1)
+        expect {
+          agent.check
+        }.to change { agent.events.count }.by(1)
 
-      expect(agent.events.last.payload).to eq ({ 'message' => 'A gap was found!',
-                                                 'gap_started_at' => agent.memory['newest_event_created_at'] })
+        expect(agent.events.last.payload).to eq ({ 'message' => 'A gap was found!',
+                                                   'gap_started_at' => agent.memory['newest_event_created_at'] })
 
-      expect {
-        agent.check
-      }.not_to change { agent.events.count }
+        expect {
+          agent.check
+        }.not_to change { agent.events.count }
+      end
+    end
+
+    context 'multisream stream' do
+      it 'alerts once for each stream for which no data has been received during window_duration_in_days' do
+        agent.options["stream_path"] = "my_option"
+        agent.memory['stream1'] = { 'newest_event_created_at' => 1.days.ago.to_i }
+        agent.memory['stream2'] = { 'newest_event_created_at' => 1.days.ago.to_i }
+        agent.memory['stream3'] = { 'newest_event_created_at' => 1.days.ago.to_i }
+
+        expect {
+          agent.check
+        }.to_not change { agent.events.count }
+
+        agent.memory['stream1'] = { 'newest_event_created_at' => 3.days.ago.to_i }
+        agent.memory['stream3'] = { 'newest_event_created_at' => 3.days.ago.to_i }
+
+        expect {
+          agent.check
+        }.to change { agent.events.count }.by(2)
+
+        expect {
+          agent.check
+        }.not_to change { agent.events.count }
+      end
+
+      it 'event should contain the failed stream' do
+        agent.options["stream_path"] = "my_option"
+        agent.memory['stream99'] = { 'newest_event_created_at' => 3.days.ago.to_i }
+
+        expect {
+          agent.check
+        }.to change { agent.events.count }.by(1)
+
+        expect(agent.events.last.payload).to eq ({ 'message' => 'A gap was found!',
+                                                   'gap_started_at' => agent.memory['stream99']['newest_event_created_at'],
+                                                   'my_option' => 'stream99'
+                                                 })
+      end
     end
   end
 end


### PR DESCRIPTION
Add the ability of the gap detector to monitor multiple streams based on a parameter in the event payload.