### PR TITLE
Agent n+1 query fixes

### DIFF
--- a/app/views/agents/_action_menu.html.erb
+++ b/app/views/agents/_action_menu.html.erb
@@ -47,7 +47,7 @@
 
   <li class="divider"></li>
 
-  <% if agent.can_create_events? && agent.events.count > 0 %>
+  <% if agent.can_create_events? && agent.events_count > 0 %>
     <li>
       <%= link_to icon_tag('glyphicon-trash', class: 'color-danger') + ' Delete all events', remove_events_agent_path(agent, return: return_to), method: :delete, data: {confirm: 'Are you sure you want to delete ALL emitted events for this Agent?'}, tabindex: "-1" %>
     </li>

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -14,7 +14,7 @@
 
           <li><a href="#logs" data-toggle="tab" data-agent-id="<%= @agent.id %>" class='<%= @agent.recent_error_logs? ? 'recent-errors' : '' %>'><span class='glyphicon glyphicon-list-alt'></span> Logs</a></li>
 
-          <% if @agent.can_create_events? && @agent.events.count > 0 %>
+          <% if @agent.can_create_events? && @agent.events_count > 0 %>
             <li><%= link_to icon_tag('glyphicon-random') + ' Events'.html_safe, agent_events_path(@agent, return: request.fullpath) %></li>
           <% else %>
             <li class='disabled'><a><span class='glyphicon glyphicon-random'></span> Events</a></li>
@@ -103,7 +103,7 @@
             <% if @agent.can_create_events? %>
               <p>
                 <b>Events created:</b>
-                <%= link_to @agent.events.count, agent_events_path(@agent) %>
+                <%= link_to @agent.events_count, agent_events_path(@agent) %>
               </p>
             <% end %>
 


### PR DESCRIPTION
Added some optimizations for code where events_count can be used without loading the entire events association, and then applying count.