### PR TITLE
Use version 1.1 of twitter stream API endpoint

### DIFF
--- a/app/models/agents/twitter_stream_agent.rb
+++ b/app/models/agents/twitter_stream_agent.rb
@@ -182,7 +182,7 @@ module Agents
         filters = filters.map(&:downcase).uniq
 
         stream = Twitter::JSONStream.connect(
-          :path    => "/1/statuses/#{(filters && filters.length > 0) ? 'filter' : 'sample'}.json#{"?track=#{filters.map {|f| CGI::escape(f) }.join(",")}" if filters && filters.length > 0}",
+          :path    => "/1.1/statuses/#{(filters && filters.length > 0) ? 'filter' : 'sample'}.json#{"?track=#{filters.map {|f| CGI::escape(f) }.join(",")}" if filters && filters.length > 0}",
           :ssl     => true,
           :oauth   => {
             :consumer_key    => agent.twitter_consumer_key,

--- a/spec/models/agents/twitter_stream_agent_spec.rb
+++ b/spec/models/agents/twitter_stream_agent_spec.rb
@@ -212,7 +212,7 @@ describe Agents::TwitterStreamAgent do
       end
 
       it "initializes Twitter::JSONStream" do
-        mock(Twitter::JSONStream).connect({:path=>"/1/statuses/filter.json?track=agent",
+        mock(Twitter::JSONStream).connect({:path=>"/1.1/statuses/filter.json?track=agent",
                                            :ssl=>true, :oauth=>{:consumer_key=>"twitteroauthkey",
                                            :consumer_secret=>"twitteroauthsecret",
                                            :access_key=>"1234token",


### PR DESCRIPTION
The v1 endpoint was discontinued at the end of april.

 #1490