### PR TITLE
Refactor agent forms

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -162,24 +162,23 @@ class AgentsController < ApplicationController
     agents = current_user.agents
 
     if id = params[:id]
-      @agent = agents.build_clone(agents.find(id))
+      agent = agents.build_clone(agents.find(id))
     else
-      @agent = agents.build
+      agent = agents.build
     end
 
-    @agent.scenario_ids = [params[:scenario_id]] if params[:scenario_id] && current_user.scenarios.find_by(id: params[:scenario_id])
-
-    initialize_presenter
+    agent.scenario_ids = [params[:scenario_id]] if params[:scenario_id] && current_user.scenarios.find_by(id: params[:scenario_id])
+    @form = AgentForm.new(agent: agent, user: current_user, view: view_context)
 
     respond_to do |format|
       format.html
-      format.json { render json: @agent }
+      format.json { render json: @form.agent }
     end
   end
 
   def edit
-    @agent = current_user.agents.find(params[:id])
-    initialize_presenter
+    agent = current_user.agents.find(params[:id])
+    @form = AgentForm.new(agent: agent, user: current_user, view: view_context)
   end
 
   def create
@@ -190,9 +189,9 @@ class AgentsController < ApplicationController
         format.html { redirect_back "'#{@agent.name}' was successfully created.", return: agents_path }
         format.json { render json: @agent, status: :ok, location: agent_path(@agent) }
       else
-        initialize_presenter
+        @form = AgentForm.new(agent: @agent, user: current_user, view: view_context)
         format.html { render action: "new" }
-        format.json { render json: @agent.errors, status: :unprocessable_entity }
+        format.json { render json: @form.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -205,9 +204,9 @@ class AgentsController < ApplicationController
         format.html { redirect_back "'#{@agent.name}' was successfully updated.", return: agents_path }
         format.json { render json: @agent, status: :ok, location: agent_path(@agent) }
       else
-        initialize_presenter
+        @form = AgentForm.new(agent: @agent, user: current_user, view: view_context)
         format.html { render action: "edit" }
-        format.json { render json: @agent.errors, status: :unprocessable_entity }
+        format.json { render json: @form.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/forms/agent_form.rb
+++ b/app/forms/agent_form.rb
@@ -1,0 +1,136 @@
+# Encapsulates the logic for editing/creating an agent.
+class AgentForm
+  extend Forwardable
+
+  # agent --- The agent to edit.
+  # user  --- The user doing the editing.
+  # view  --- The view context for generating the form.
+  def initialize(agent:, user: agent.user, view:)
+    @agent = agent
+    @user = user
+    @view = view
+    if @agent.try(:is_form_configurable?)
+      @agent = FormConfigurableAgentPresenter.new(agent, view)
+    end
+  end
+
+  attr_reader :agent
+  def_delegators :agent, :errors, :keep_events_for, :new_record?, :short_type
+  def_delegator :user, :scenarios?
+  alias_method :changeable_type?, :new_record?
+
+  def agent_type_select
+    AgentTypeSelector.new(select_id: :type, selected: agent.type, user: user, view: view)
+  end
+
+  def attrs
+    {
+      as: :agent,
+      html: {class: 'agent-form'},
+      method: method,
+      url: url,
+    }
+  end
+
+  def controllers?
+    !agent.controllers.empty?
+  end
+
+  def controls_others?
+    agent.can_control_other_agents?
+  end
+
+  def control_targets_select
+    Select2Selector.new(agent_params(select_id: :control_target_ids, selected: agent.control_target_ids))
+  end
+
+  def creates_events?
+    agent.can_create_events?
+  end
+
+  def error_messages
+    errors.full_messages
+  end
+
+  def errors?
+    errors.any?
+  end
+
+  def event_sources_select
+    Select2Selector.new(agent_params(filter: :can_create_events?, select_id: :source_ids, selected: agent.source_ids))
+  end
+
+  def event_targets_select
+    Select2Selector.new(agent_params(filter: :can_receive_events?, select_id: :receiver_ids, selected: agent.receiver_ids))
+  end
+
+  def html_description
+    agent.try(:html_description)
+  end
+
+  def keep_events_select
+    Selector.new(data: retention_schedules, selected: agent.keep_events_for, select_id: :keep_events_for, view: view)
+  end
+
+  def links
+    @links ||= {
+      back: view.agents_path,
+      show: view.agent_path(agent)
+    }
+  end
+
+  def number_of_errors
+    errors.count
+  end
+
+  def receives_events?
+    agent.can_receive_events?
+  end
+
+  def schedulable?
+    agent.can_be_scheduled?
+  end
+
+  def scenarios_select
+    Select2Selector.new(data: user.scenarios, select_id: :scenario_ids, selected: agent.scenario_ids, url_prefix: '/scenarios', view: view)
+  end
+
+  def schedule_select
+    ScheduleSelector.new(select_id: :schedule, selected: agent.schedule, view: view)
+  end
+
+  private
+
+  attr_reader :user
+  attr_reader :view
+
+  def agent_params(params)
+    {data: other_agents, url_prefix: '/agents', view: view}.merge(params)
+  end
+
+  def method
+    if new_record?
+      'POST'
+    else
+      'PUT'
+    end
+  end
+
+  def other_agents
+    @other_agents ||= user.agents.where.not(id: agent.id)
+  end
+
+  def retention_schedules
+    Agent::EVENT_RETENTION_SCHEDULES.map { |name, time|
+      Selector::Container.new(name, time)
+    }
+  end
+
+  def url
+    if new_record?
+      view.agents_path
+    else
+      view.agent_path(agent)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,4 +80,8 @@ class User < ActiveRecord::Base
   def requires_no_invitation_code?
     !!@requires_no_invitation_code
   end
+
+  def scenarios?
+    scenario_count > 0
+  end
 end

--- a/app/presenters/agent_type_selector.rb
+++ b/app/presenters/agent_type_selector.rb
@@ -1,0 +1,43 @@
+# Encapsulates the logic for an HTML agent type selector.
+class AgentTypeSelector < Selector
+  # user --- The user for whom the agent list should be generated.
+  def initialize(user:, **args)
+    super(args)
+    @user = user
+  end
+
+  protected
+
+  def choices
+    [no_element_choice] + agent_choices
+  end
+
+  private
+
+  attr_reader :user
+
+  def agent_choices
+    Agent.types.map { |type|
+      [
+        humanize_name(type.name),
+        type,
+        {title: html_description(type.name)}
+      ]
+    }
+  end
+
+  def html_description(name)
+    description = Agent.build_for_type(name, user, {}).html_description
+    short_description = description.lines.first.strip
+
+    view.__send__(:h, short_description)
+  end
+
+  def humanize_name(name)
+    name.gsub(/^.*::/, '').underscore.humanize.titleize
+  end
+
+  def no_element_choice
+    ['Select an Agent Type', 'Agent', {title: ''}]
+  end
+end

--- a/app/presenters/agent_type_selector.rb
+++ b/app/presenters/agent_type_selector.rb
@@ -23,7 +23,7 @@ class AgentTypeSelector < Selector
         type,
         {title: html_description(type.name)}
       ]
-    }
+    }.sort_by(&:first)
   end
 
   def html_description(name)

--- a/app/presenters/schedule_selector.rb
+++ b/app/presenters/schedule_selector.rb
@@ -1,0 +1,13 @@
+# Encapsulates the logic for an HTML schedule selector.
+class ScheduleSelector < Selector
+  # data is automatically set to the data source to separate concerns.
+  def initialize(data: Agent::SCHEDULES, **args)
+    super
+  end
+
+  protected
+
+  def choices
+    data.map { |schedule| [schedule.humanize.titleize, schedule] }
+  end
+end

--- a/app/presenters/select2_selector.rb
+++ b/app/presenters/select2_selector.rb
@@ -1,0 +1,27 @@
+# Encapsulates the logic for a select2-based HTML selector.
+class Select2Selector < Selector
+  # url_prefix --- The url prefix to set within the select2 element.
+  def initialize(url_prefix:, **args)
+    super(args)
+    @url_prefix = url_prefix
+  end
+
+  protected
+
+  def html_options
+    {
+      multiple: true,
+      size: 5,
+      class: 'select2-linked-tags form-control',
+      data: {url_prefix: url_prefix},
+    }
+  end
+
+  private
+
+  attr_reader :url_prefix
+
+  def filtered_data
+    data.select(&filter)
+  end
+end

--- a/app/presenters/selector.rb
+++ b/app/presenters/selector.rb
@@ -1,0 +1,79 @@
+# Encapsulates the logic for an HTML selector.
+#
+# Example:
+#
+#   # In the controller
+#   data = (1..10).map { |i| Selector::Container.new("value #{i}", i) }
+#   @selector = Selector.new(data: data, select_id: :my_attr, selected: 1, view: view_context)
+#
+#   # In the view
+#   = f.select *selector
+#
+# When subclassing a Selector, there are two easy points for extension:
+#
+# * `#choices` should output data in the form expected by
+#   `ActionView::Helpers::FormOptionsHelper#options_for_select`.
+# * `#html_options` should output a hash that is sent as `html_options` in
+#   `ActionView::Helpers::FormBuilder#select`.
+# * `#options` should output a hash that is sent as `options` in
+#   `ActionView::Helpers::FormBuilder#select`.
+class Selector
+  Container = Struct.new(:name, :id, :title)
+
+  # data      --- The data to format for the selector options.
+  # filter    --- A symbol id of a predicate to apply when filtering the data.
+  # select_id --- The value to use for the "id" attr on the select element.
+  # selected  --- The selected value in the selector.
+  # view      --- The view context for generating the HTML.
+  def initialize(data: [], filter: :present?, select_id:, selected:, view:)
+    @data       = data
+    @filter     = filter
+    @select_id  = select_id
+    @selected   = selected
+    @view       = view
+  end
+
+  # Returns an array of items that can be passed to
+  # `ActionView::Helpers::FormBuilder#select` with a splat.
+  #
+  # This is aliased to `#to_a` which allows you to splat the object.
+  #
+  # Example
+  #
+  #   <%= f.select *selector.as_select %>
+  def as_select
+    [
+      select_id,
+      view.options_for_select(choices, selected),
+      options,
+      html_options
+    ]
+  end
+  alias_method :to_a, :as_select
+
+  protected
+
+  def choices
+    filtered_data.map { |datum| [datum.name, datum.id] }
+  end
+
+  def html_options
+    {class: 'form-control'}
+  end
+
+  def options
+    {}
+  end
+
+  private
+
+  attr_reader :data
+  attr_reader :filter
+  attr_reader :select_id
+  attr_reader :selected
+  attr_reader :view
+
+  def filtered_data
+    data.select(&filter)
+  end
+end

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="row well model-errors">
     <h2><%= pluralize(@form.number_of_errors, "error") %> prohibited this Agent from being saved:</h2>
     <% @form.error_messages.each do |msg| %>
-      <p class='text-warning'><%= msg %></p>
+      <p class="text-warning"><%= msg %></p>
     <% end %>
   </div>
 <% end %>
@@ -29,20 +29,20 @@
           <div class="col-md-12">
             <div class="form-group">
               <%= f.label :name %>
-              <%= f.text_field :name, :class => 'form-control' %>
+              <%= f.text_field :name, :class => "form-control" %>
             </div>
 
-            <div class='oauthable-form'>
-              <%= render partial: 'oauth_dropdown', locals: { agent: @form.agent } %>
+            <div class="oauthable-form">
+              <%= render partial: "oauth_dropdown", locals: { agent: @form.agent } %>
             </div>
 
             <div class="form-group">
-              <%= f.label :schedule, :class => 'control-label' %>
+              <%= f.label :schedule, :class => "control-label" %>
               <div class="schedule-region" data-can-be-scheduled="<%= @form.schedulable? %>">
                 <div class="can-be-scheduled">
                   <%= f.select(*@form.schedule_select) %>
                 </div>
-                <span class='cannot-be-scheduled text-info'>This type of Agent cannot be scheduled.</span>
+                <span class="cannot-be-scheduled text-info">This type of Agent cannot be scheduled.</span>
               </div>
             </div>
 
@@ -51,7 +51,7 @@
                 <%= f.label :controllers %>
                 <span class="glyphicon glyphicon-question-sign hover-help" data-content="Other than the system-defined schedule above, this agent may be run or controlled by these user-defined Agents."></span>
                 <div class="controller-list">
-                  <%= agent_controllers(@form.agent) || 'None' %>
+                  <%= agent_controllers(@form.agent) || "None" %>
                 </div>
               </div>
             </div>
@@ -65,7 +65,7 @@
               </div>
             </div>
 
-            <div class='event-related-region' data-can-create-events="<%= @form.creates_events? %>">
+            <div class="event-related-region" data-can-create-events="<%= @form.creates_events? %>">
               <div class="form-group">
                 <%= f.label :keep_events_for, "Keep events" %>
                 <span class="glyphicon glyphicon-question-sign hover-help" data-content="In order to conserve disk space, you can choose to have events created by this Agent expire after a certain period of time.  Make sure you keep them long enough to allow any subsequent Agents to make use of them."></span>
@@ -78,8 +78,8 @@
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
               <div class="link-region" data-can-receive-events="<%= @form.receives_events? %>">
                 <%= f.select(*@form.event_sources_select) %>
-                <span class='cannot-receive-events text-info'>This type of Agent cannot receive events.</span>
-                <%= f.label :propagate_immediately, :class => 'propagate-immediately' do %>Propagate immediately
+                <span class="cannot-receive-events text-info">This type of Agent cannot receive events.</span>
+                <%= f.label :propagate_immediately, :class => "propagate-immediately" do %>Propagate immediately
                   <%= f.check_box :propagate_immediately %>
                   &nbsp;
                   <span class="glyphicon glyphicon-question-sign hover-help" data-content="Normally, Huginn moves Events from source Agents to receiving Agents once per minute. Checking this option will cause Events created by this Agent's sources to be received immediately. This can use more CPU resources, but will decrease the time between Event creation and being received by this Agent."></span>
@@ -92,7 +92,7 @@
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="Events created by this Agent will be sent to the selected Agents."></span>
               <div class="event-related-region">
                 <%= f.select(*@form.event_targets_select) %>
-                <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>
+                <span class="cannot-create-events text-info">This type of Agent cannot create events.</span>
               </div>
             </div>
 
@@ -107,7 +107,7 @@
           </div>
 
           <div class="col-md-12 agent-options">
-            <%= render partial: 'options', locals: { agent: @form.agent } %>
+            <%= render partial: "options", locals: { agent: @form.agent } %>
           </div>
         </div>
       </div>
@@ -116,7 +116,7 @@
     <div class="col-md-6">
       <div class="row">
         <div class="col-md-12">
-          <div class='well description'>
+          <div class="well description">
             <%= @form.html_description %>
           </div>
         </div>
@@ -124,7 +124,7 @@
 
       <div class="row">
         <div class="col-md-12">
-          <div class='well event-descriptions' style='display: none'></div>
+          <div class="well event-descriptions" style="display: none"></div>
         </div>
       </div>
     </div>

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -1,20 +1,15 @@
 <% load_ace_editor! %>
 
-<% if @agent.errors.any? %>
+<% if @form.errors? %>
   <div class="row well model-errors">
-    <h2><%= pluralize(@agent.errors.count, "error") %> prohibited this Agent from being saved:</h2>
-    <% @agent.errors.full_messages.each do |msg| %>
+    <h2><%= pluralize(@form.number_of_errors, "error") %> prohibited this Agent from being saved:</h2>
+    <% @form.error_messages.each do |msg| %>
       <p class='text-warning'><%= msg %></p>
     <% end %>
   </div>
 <% end %>
 
-<%= form_for(@agent,
-             as: :agent,
-             url: @agent.new_record? ? agents_path : agent_path(@agent),
-             method: @agent.new_record? ? "POST" : "PUT",
-             html: { class: 'agent-form' }) do |f| %>
-
+<%= form_for @form.agent, @form.attrs do |f| %>
   <%= hidden_field_tag :return, params[:return] %>
 
   <div class="row">
@@ -22,10 +17,10 @@
       <div class="row">
 
         <div class="col-md-12">
-          <% if @agent.new_record? %>
+          <% if @form.changeable_type? %>
             <div class="form-group type-select">
               <%= f.label :type %>
-              <%= f.select :type, options_for_select([['Select an Agent Type', 'Agent', {title: ''}]] + Agent.types.map {|type| [type.name.gsub(/^.*::/, '').underscore.humanize.titleize, type, {title: h(Agent.build_for_type(type.name,current_user,{}).html_description.lines.first.strip)}] }, @agent.type), {}, :class => 'form-control' %>
+              <%= f.select(*@form.agent_type_select) %>
             </div>
           <% end %>
         </div>
@@ -38,58 +33,51 @@
             </div>
 
             <div class='oauthable-form'>
-              <%= render partial: 'oauth_dropdown', locals: { agent: @agent } %>
+              <%= render partial: 'oauth_dropdown', locals: { agent: @form.agent } %>
             </div>
 
             <div class="form-group">
               <%= f.label :schedule, :class => 'control-label' %>
-              <div class="schedule-region" data-can-be-scheduled="<%= @agent.can_be_scheduled? %>">
+              <div class="schedule-region" data-can-be-scheduled="<%= @form.schedulable? %>">
                 <div class="can-be-scheduled">
-                  <%= f.select :schedule, options_for_select(Agent::SCHEDULES.map {|s| [s.humanize.titleize, s] }, @agent.schedule), {}, :class => 'form-control' %>
+                  <%= f.select(*@form.schedule_select) %>
                 </div>
                 <span class='cannot-be-scheduled text-info'>This type of Agent cannot be scheduled.</span>
               </div>
             </div>
 
-            <div class="controller-region" data-has-controllers="<%= !@agent.controllers.empty? %>">
+            <div class="controller-region" data-has-controllers="<%= !@form.controllers? %>">
               <div class="form-group">
                 <%= f.label :controllers %>
                 <span class="glyphicon glyphicon-question-sign hover-help" data-content="Other than the system-defined schedule above, this agent may be run or controlled by these user-defined Agents."></span>
                 <div class="controller-list">
-                  <%= agent_controllers(@agent) || 'None' %>
+                  <%= agent_controllers(@form.agent) || 'None' %>
                 </div>
               </div>
             </div>
 
-            <div class="control-link-region" data-can-control-other-agents="<%= @agent.can_control_other_agents? %>">
+            <div class="control-link-region" data-can-control-other-agents="<%= @form.controls_others? %>">
               <div class="can-control-other-agents">
                 <div class="form-group">
                   <%= f.label :control_targets %>
-                  <%= f.select(:control_target_ids,
-                               options_for_select(current_user.agents.map {|s| [s.name, s.id] },
-                                                  @agent.control_target_ids),
-                               {}, { multiple: true, size: 5, class: 'select2-linked-tags form-control', data: {url_prefix: '/agents'}}) %>
+                  <%= f.select(*@form.control_targets_select) %>
                 </div>
               </div>
             </div>
 
-            <div class='event-related-region' data-can-create-events="<%= @agent.can_create_events? %>">
+            <div class='event-related-region' data-can-create-events="<%= @form.creates_events? %>">
               <div class="form-group">
                 <%= f.label :keep_events_for, "Keep events" %>
                 <span class="glyphicon glyphicon-question-sign hover-help" data-content="In order to conserve disk space, you can choose to have events created by this Agent expire after a certain period of time.  Make sure you keep them long enough to allow any subsequent Agents to make use of them."></span>
-                <%= f.select :keep_events_for, options_for_select(Agent::EVENT_RETENTION_SCHEDULES, @agent.keep_events_for), {}, :class => 'form-control' %>
+                <%= f.select(*@form.keep_events_select) %>
               </div>
             </div>
 
             <div class="form-group">
               <%= f.label :sources %>
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
-              <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
-                <% eventSources = (current_user.agents - [@agent]).find_all { |a| a.can_create_events? } %>
-                <%= f.select(:source_ids,
-                             options_for_select(eventSources.map {|s| [s.name, s.id] },
-                                                @agent.source_ids),
-                             {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
+              <div class="link-region" data-can-receive-events="<%= @form.receives_events? %>">
+                <%= f.select(*@form.event_sources_select) %>
                 <span class='cannot-receive-events text-info'>This type of Agent cannot receive events.</span>
                 <%= f.label :propagate_immediately, :class => 'propagate-immediately' do %>Propagate immediately
                   <%= f.check_box :propagate_immediately %>
@@ -103,29 +91,23 @@
               <%= f.label :receivers %>
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="Events created by this Agent will be sent to the selected Agents."></span>
               <div class="event-related-region">
-                <% eventTargets = (current_user.agents - [@agent]).find_all { |a| a.can_receive_events? } %>
-                <%= f.select(:receiver_ids,
-                             options_for_select(eventTargets.map {|s| [s.name, s.id] },
-                                                @agent.receiver_ids),
-                             {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
+                <%= f.select(*@form.event_targets_select) %>
                 <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>
               </div>
             </div>
 
-            <% if current_user.scenario_count > 0 %>
+            <% if @form.scenarios? %>
               <div class="form-group">
                 <%= f.label :scenarios %>
                 <span class="glyphicon glyphicon-question-sign hover-help" data-content="Use Scenarios to group sets of Agents, both for organization, and to make them easy to export and share."></span>
-                <%= f.select(:scenario_ids,
-                             options_for_select(current_user.scenarios.pluck(:name, :id), @agent.scenario_ids),
-                             {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/scenarios'} }) %>
+                <%= f.select(*@form.scenarios_select) %>
               </div>
             <% end %>
 
           </div>
 
           <div class="col-md-12 agent-options">
-            <%= render partial: 'options', locals: { agent: @agent } %>
+            <%= render partial: 'options', locals: { agent: @form.agent } %>
           </div>
         </div>
       </div>
@@ -135,7 +117,7 @@
       <div class="row">
         <div class="col-md-12">
           <div class='well description'>
-            <%= @agent.html_description unless @agent.new_record? %>
+            <%= @form.html_description %>
           </div>
         </div>
       </div>

--- a/app/views/agents/edit.html.erb
+++ b/app/views/agents/edit.html.erb
@@ -3,7 +3,7 @@
     <div class="col-md-12">
       <div class="page-header">
         <h2>
-          Editing your <%= @agent.short_type %>
+          Editing your <%= @form.short_type %>
           <%= image_tag "spinner-arrows.gif", :class => "spinner", :id => 'agent-spinner' %>
         </h2>
       </div>
@@ -18,8 +18,8 @@
   <div class="row">
     <div class="col-md-12">
       <div class="btn-group">
-        <%= link_to icon_tag('glyphicon-chevron-left') + ' Back', agents_path, class: "btn btn-default" %>
-        <%= link_to icon_tag('glyphicon-asterisk') + ' Show', agent_path(@agent), class: "btn btn-default" %>
+        <%= link_to icon_tag('glyphicon-chevron-left') + ' Back', @form.links[:back], class: "btn btn-default" %>
+        <%= link_to icon_tag('glyphicon-asterisk') + ' Show', @form.links[:show], class: "btn btn-default" %>
       </div>
     </div>
   </div>

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -124,7 +124,7 @@ describe AgentsController do
       it "opens a clone of a given Agent" do
         sign_in users(:bob)
         get :new, :id => agents(:bob_website_agent).to_param
-        expect(assigns(:agent).attributes).to eq(users(:bob).agents.build_clone(agents(:bob_website_agent)).attributes)
+        expect(assigns(:form).agent.attributes).to eq(users(:bob).agents.build_clone(agents(:bob_website_agent)).attributes)
       end
 
       it "only allows the current user to clone his own Agent" do
@@ -140,13 +140,13 @@ describe AgentsController do
       it 'populates the assigned agent with the scenario' do
         sign_in users(:bob)
         get :new, :scenario_id => scenarios(:bob_weather).id
-        expect(assigns(:agent).scenario_ids).to eq([scenarios(:bob_weather).id])
+        expect(assigns(:form).agent.scenario_ids).to eq([scenarios(:bob_weather).id])
       end
 
       it "does not see other user's scenarios" do
         sign_in users(:bob)
         get :new, :scenario_id => scenarios(:jane_weather).id
-        expect(assigns(:agent).scenario_ids).to eq([])
+        expect(assigns(:form).agent.scenario_ids).to eq([])
       end
     end
   end
@@ -155,7 +155,7 @@ describe AgentsController do
     it "only shows Agents for the current user" do
       sign_in users(:bob)
       get :edit, :id => agents(:bob_website_agent).to_param
-      expect(assigns(:agent)).to eq(agents(:bob_website_agent))
+      expect(assigns(:form).agent).to eq(agents(:bob_website_agent))
 
       expect {
         get :edit, :id => agents(:jane_website_agent).to_param
@@ -169,28 +169,28 @@ describe AgentsController do
       expect {
         post :create, :agent => valid_attributes(:type => "Agents::ThisIsFake")
       }.not_to change { users(:bob).agents.count }
-      expect(assigns(:agent)).to be_a(Agent)
-      expect(assigns(:agent)).to have(1).error_on(:type)
+      expect(assigns(:form).agent).to be_a(Agent)
+      expect(assigns(:form).agent).to have(1).error_on(:type)
 
       sign_in users(:bob)
       expect {
         post :create, :agent => valid_attributes(:type => "Object")
       }.not_to change { users(:bob).agents.count }
-      expect(assigns(:agent)).to be_a(Agent)
-      expect(assigns(:agent)).to have(1).error_on(:type)
+      expect(assigns(:form).agent).to be_a(Agent)
+      expect(assigns(:form).agent).to have(1).error_on(:type)
       sign_in users(:bob)
 
       expect {
         post :create, :agent => valid_attributes(:type => "Agent")
       }.not_to change { users(:bob).agents.count }
-      expect(assigns(:agent)).to be_a(Agent)
-      expect(assigns(:agent)).to have(1).error_on(:type)
+      expect(assigns(:form).agent).to be_a(Agent)
+      expect(assigns(:form).agent).to have(1).error_on(:type)
 
       expect {
         post :create, :agent => valid_attributes(:type => "User")
       }.not_to change { users(:bob).agents.count }
-      expect(assigns(:agent)).to be_a(Agent)
-      expect(assigns(:agent)).to have(1).error_on(:type)
+      expect(assigns(:form).agent).to be_a(Agent)
+      expect(assigns(:form).agent).to have(1).error_on(:type)
     end
 
     it "creates Agents for the current user" do
@@ -220,7 +220,7 @@ describe AgentsController do
       expect {
         post :create, :agent => valid_attributes(:name => "")
       }.not_to change { users(:bob).agents.count }
-      expect(assigns(:agent)).to have(1).errors_on(:name)
+      expect(assigns(:form).agent).to have(1).errors_on(:name)
       expect(response).to render_template("new")
     end
 
@@ -238,7 +238,7 @@ describe AgentsController do
     it "does not allow changing types" do
       sign_in users(:bob)
       post :update, :id => agents(:bob_website_agent).to_param, :agent => valid_attributes(:type => "Agents::WeatherAgent")
-      expect(assigns(:agent)).to have(1).errors_on(:type)
+      expect(assigns(:form).agent).to have(1).errors_on(:type)
       expect(response).to render_template("edit")
     end
 
@@ -264,19 +264,19 @@ describe AgentsController do
     it "will not accept Agent sources owned by other users" do
       sign_in users(:bob)
       post :update, :id => agents(:bob_website_agent).to_param, :agent => valid_attributes(:source_ids => [agents(:jane_weather_agent).id])
-      expect(assigns(:agent)).to have(1).errors_on(:sources)
+      expect(assigns(:form).agent).to have(1).errors_on(:sources)
     end
 
     it "will not accept Scenarios owned by other users" do
       sign_in users(:bob)
       post :update, :id => agents(:bob_website_agent).to_param, :agent => valid_attributes(:scenario_ids => [scenarios(:jane_weather).id])
-      expect(assigns(:agent)).to have(1).errors_on(:scenarios)
+      expect(assigns(:form).agent).to have(1).errors_on(:scenarios)
     end
 
     it "shows errors" do
       sign_in users(:bob)
       post :update, :id => agents(:bob_website_agent).to_param, :agent => valid_attributes(:name => "")
-      expect(assigns(:agent)).to have(1).errors_on(:name)
+      expect(assigns(:form).agent).to have(1).errors_on(:name)
       expect(response).to render_template("edit")
     end
 


### PR DESCRIPTION
When I started studying Huginn to be able to start contributing, I noticed one part that I felt I could jump into right away: cleaning up the views and controllers.

This goes through and cleans up the agent form by introducing a form object (and collaborators) that encapsulate all the logic in the view. This makes the view more declarative, so it's hopefully easier to understand and debug. There's still some refactoring that can be done (the AgentForm class is pretty long as it has a lot to do) but I think it's a good start.

I hope you are open to this type of contribution! I think the project is really interesting and am planning to help out more as I get a better understanding of it.