### PR TITLE
Add time tracking to http status agent

### DIFF
--- a/lib/time_tracker.rb
+++ b/lib/time_tracker.rb
@@ -2,9 +2,9 @@ class TimeTracker
   attr_accessor :elapsed_time, :result
 
   def self.track
-    start = Process.clock_gettime(Process::CLOCK_REALTIME)
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result = yield
-    new(Process.clock_gettime(Process::CLOCK_REALTIME) - start, result)
+    new(Process.clock_gettime(Process::CLOCK_MONOTONIC) - start, result)
   end
 
   def initialize(elapsed_time, result)

--- a/lib/time_tracker.rb
+++ b/lib/time_tracker.rb
@@ -1,0 +1,22 @@
+class TimeTracker
+  attr_accessor :elapsed_time, :result
+
+  def self.track
+    start = Process.clock_gettime(Process::CLOCK_REALTIME)
+    result = yield
+    new(Process.clock_gettime(Process::CLOCK_REALTIME) - start, result)
+  end
+
+  def initialize(elapsed_time, result)
+    @elapsed_time = elapsed_time
+    @result = result
+  end
+
+  def method_missing(method_sym, *arguments, &block)
+    if @result.respond_to?(method_sym)
+      @result.send(method_sym, *arguments, &block)
+    else
+      super
+    end
+  end
+end

--- a/spec/controllers/http_status_agent_spec.rb
+++ b/spec/controllers/http_status_agent_spec.rb
@@ -133,6 +133,11 @@ describe 'HttpStatusAgent' do
         expect(agent.memory['last_status']).to eq('200')
       end
 
+      it "should record the time spent waiting for the reply" do
+        agent.receive events
+        expect(agent.the_created_events[0][:payload]['elapsed_time']).not_to be_nil
+      end
+
       describe "but the status code is not 200" do
         let(:status_code) { 500 }
 
@@ -234,6 +239,12 @@ describe 'HttpStatusAgent' do
           agent.receive events
           expect(agent.the_created_events[0][:payload]['url']).to eq(successful_url)
           expect(agent.the_created_events[1][:payload]['url']).to eq(failing_url)
+        end
+
+        it "should record the time spent waiting for the reply" do
+          agent.receive events
+          expect(agent.the_created_events[0][:payload]['elapsed_time']).not_to be_nil
+          expect(agent.the_created_events[1][:payload]['elapsed_time']).not_to be_nil
         end
 
       end

--- a/spec/lib/time_tracker_spec.rb
+++ b/spec/lib/time_tracker_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe TimeTracker do
+  describe "#track" do
+    it "tracks execution time" do
+      tracked_result = TimeTracker.track { sleep(0.01) }
+      expect(tracked_result.elapsed_time).to satisfy {|v| v > 0.01 && v < 0.1}
+    end
+
+    it "returns the proc return value" do
+      tracked_result = TimeTracker.track { 42 }
+      expect(tracked_result.result).to eq(42)
+    end
+
+    it "returns an object that behaves like the proc result" do
+      tracked_result = TimeTracker.track { 42 }
+      expect(tracked_result.to_i).to eq(42)
+      expect(tracked_result + 1).to eq(43)
+    end
+  end
+end


### PR DESCRIPTION
I missed having how much time it took to get the http status from the url, so I added it myself.

The idea is to use a peak detector to check availability of a site.