### PR TITLE
Javascript Agent Hash and Array memory

### DIFF
--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -220,9 +220,9 @@ module Agents
     end
 
     def clean_nans(input)
-      if input.is_a?(Array)
+      if input.is_a?(V8::Array)
         input.map {|v| clean_nans(v) }
-      elsif input.is_a?(Hash)
+      elsif input.is_a?(V8::Object)
         input.inject({}) { |m, (k, v)| m[k] = clean_nans(v); m }
       elsif input.is_a?(Float) && input.nan?
         'NaN'

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -132,12 +132,57 @@ describe Agents::JavaScriptAgent do
         expect(AgentLog.last.message).to match(/oh no/)
         expect(AgentLog.last.level).to eq(4)
       end
+    end
 
+    describe "getMemory" do
       it "won't store NaNs" do
         @agent.options['code'] = 'Agent.check = function() { this.memory("foo", NaN); };'
         @agent.save!
         @agent.check
         expect(@agent.memory['foo']).to eq('NaN') # string
+        @agent.save!
+        expect { @agent.reload.memory }.not_to raise_error
+      end
+
+      it "it stores an Array" do
+        @agent.options['code'] = 'Agent.check = function() {
+          var arr = [1,2];
+          this.memory("foo", arr);
+          };'
+        @agent.save!
+        @agent.check
+        expect(@agent.memory['foo']).to eq([1,2])
+        @agent.save!
+        expect { @agent.reload.memory }.not_to raise_error
+      end
+
+      it "it stores a Hash" do
+        @agent.options['code'] = 'Agent.check = function() {
+          var obj = {};
+          obj["one"] = 1;
+          obj["two"] = [1,2];
+          this.memory("foo", obj);
+          };'
+        @agent.save!
+        @agent.check
+        expect(@agent.memory['foo']).to eq({"one"=>1, "two"=> [1,2]})
+        @agent.save!
+        expect { @agent.reload.memory }.not_to raise_error
+      end
+
+      it "it stores a nested Hash" do
+        @agent.options['code'] = 'Agent.check = function() {
+          var u = {};
+          u["one"] = 1;
+          u["two"] = 2;
+          var obj = {};
+          obj["three"] = 3;
+          obj["four"] = u;
+          this.memory("foo", obj);
+          };'
+        @agent.save!
+        @agent.check
+        expect(@agent.memory['foo']).to eq({"three"=>3, "four"=>{"one"=>1, "two"=>2}})
         @agent.save!
         expect { @agent.reload.memory }.not_to raise_error
       end


### PR DESCRIPTION
Not sure if it's a bug or i'm using it wrong. For a Javascriptagent i tried to store an Array or Javascript Object/Hash in memory. But when i dryrun the Agent with 
```
Agent.check = function() {
  var h = new Object(); // or just {}
  h['one'] = 1;
  h['two'] = 2;
  h['three'] = u;
  var z = [1,2];

  this.memory("test1",h);
  this.memory("test2",z);

};
```
i get this output for memory
```
{
  "test1": "[object Object]",
  "test2": "1,2"
}
```
With the changes in the PR i get
```
{
  "test1": {
    "one": 1,
    "two": 2,
    "three": 3
  },
  "test2": [
    1,
    2
  ]
}
```
