### PR TITLE
Use a random port in MQTT::FakeServer

### DIFF
--- a/spec/models/agents/mqtt_agent_spec.rb
+++ b/spec/models/agents/mqtt_agent_spec.rb
@@ -7,7 +7,7 @@ describe Agents::MqttAgent do
   before :each do
     @error_log = StringIO.new
 
-    @server = MQTT::FakeServer.new(41234, '127.0.0.1')
+    @server = MQTT::FakeServer.new('127.0.0.1')
     @server.logger = Logger.new(@error_log)
     @server.logger.level = Logger::DEBUG
     @server.start

--- a/spec/support/fake_mqtt_server.rb
+++ b/spec/support/fake_mqtt_server.rb
@@ -35,8 +35,7 @@ class MQTT::FakeServer
   #
   # If no port is given, bind to a random port number
   # If no bind address is given, bind to localhost
-  def initialize(port=nil, bind_address='127.0.0.1')
-    @port = port
+  def initialize(bind_address='127.0.0.1')
     @address = bind_address
   end
 
@@ -47,7 +46,7 @@ class MQTT::FakeServer
 
   # Start the thread and open the socket that will process client connections
   def start
-    @socket ||= TCPServer.new(@address, @port)
+    @socket ||= TCPServer.new(@address, 0)
     @address = @socket.addr[3]
     @port = @socket.addr[1]
     @thread ||= Thread.new do


### PR DESCRIPTION
Fixes random spec failures on CI which happended when the hard coded port was already in use.