### PR TITLE
Write supervisor socked to /dev/shm in multi process docker file

### DIFF
--- a/docker/multi-process/scripts/init
+++ b/docker/multi-process/scripts/init
@@ -56,21 +56,42 @@ case "${DATABASE_ADAPTER}" in
 esac
 
 # initialize supervisord config
+cat > /etc/supervisor/supervisord.conf <<EOF
+[unix_http_server]
+file=/dev/shm/supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
 
-cat > /etc/supervisor/conf.d/supervisord.conf <<EOF
 [supervisord]
 nodaemon = true
 user = root
 stdout_logfile = AUTO
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
 
-[unix_http_server]
-file=/var/run/supervisor.sock   ; (the path to the socket file)
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///dev/shm/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [eventlistener:stdout]
 command = supervisor_stdout
 buffer_size = 100
 events = PROCESS_LOG
 result_handler = supervisor_stdout:event_handler
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor/conf.d/*.conf
 EOF
 
 # prepare the supervisord bootstrap service script


### PR DESCRIPTION
Fixes running the multi-process docker image on the overlay storage driver which currently has issues with unix sockets.
Merges the default supervisord configuration options of /etc/supervisor/supervisord.conf with our previous overrides of /etc/supervisor/conf.d/supervisord.conf.

Fixes #1502