### PR TITLE
Add deleteKey function to Javascript Agent

### DIFF
--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -121,7 +121,7 @@ module Agents
           memory.to_json
         end
       end
-      context["deleteKey"] = lambda { |a, x| memory.delete(x) }
+      context["deleteKey"] = lambda { |a, x| memory.delete(x).to_json }
       context["escapeHtml"] = lambda { |a, x| CGI.escapeHTML(x) }
       context["unescapeHtml"] = lambda { |a, x| CGI.unescapeHTML(x) }
       context['getCredential'] = lambda { |a, k| credential(k); }
@@ -201,7 +201,7 @@ module Agents
         }
 
         Agent.deleteKey = function(key) {
-          return deleteKey(key);
+          return JSON.parse(deleteKey(key));
         }
 
         Agent.escapeHtml = function(html) {

--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -21,6 +21,7 @@ module Agents
       * `this.memory()`
       * `this.memory(key)`
       * `this.memory(keyToSet, valueToSet)`
+      * `this.deleteKey(key)` (deletes a key from memory and returns the value)
       * `this.credential(name)`
       * `this.credential(name, valueToSet)`
       * `this.options()`
@@ -120,6 +121,7 @@ module Agents
           memory.to_json
         end
       end
+      context["deleteKey"] = lambda { |a, x| memory.delete(x) }
       context["escapeHtml"] = lambda { |a, x| CGI.escapeHTML(x) }
       context["unescapeHtml"] = lambda { |a, x| CGI.unescapeHTML(x) }
       context['getCredential'] = lambda { |a, k| credential(k); }
@@ -196,6 +198,10 @@ module Agents
 
         Agent.error = function(message) {
           doError(message);
+        }
+
+        Agent.deleteKey = function(key) {
+          return deleteKey(key);
         }
 
         Agent.escapeHtml = function(html) {

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -188,6 +188,30 @@ describe Agents::JavaScriptAgent do
       end
     end
 
+    describe "deleteKey" do
+      it "deletes a memory key" do
+        @agent.memory = { foo: "baz"}
+        @agent.options['code'] = 'Agent.check = function() {
+          this.deleteKey("foo");
+          };'
+        @agent.save!
+        @agent.check
+        expect(@agent.memory['foo']).to be_nil
+        expect { @agent.reload.memory }.not_to raise_error
+      end
+
+      it " returns the value of the deleted key" do
+        @agent.memory = { foo: "baz"}
+        @agent.options['code'] = 'Agent.check = function() {
+          this.createEvent({ message: this.deleteKey("foo")});
+          };'
+        @agent.save!
+        @agent.check
+        created_event = @agent.events.last
+        expect(created_event.payload).to eq({ 'message' => "baz" })
+      end
+    end
+
     describe "creating events" do
       it "creates events with this.createEvent in the JavaScript environment" do
         @agent.options['code'] = 'Agent.check = function() { this.createEvent({ message: "This is an event!", stuff: { foo: 5 } }); };'

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -190,7 +190,7 @@ describe Agents::JavaScriptAgent do
 
     describe "deleteKey" do
       it "deletes a memory key" do
-        @agent.memory = { foo: "baz"}
+        @agent.memory = { foo: "baz" }
         @agent.options['code'] = 'Agent.check = function() {
           this.deleteKey("foo");
           };'
@@ -200,15 +200,26 @@ describe Agents::JavaScriptAgent do
         expect { @agent.reload.memory }.not_to raise_error
       end
 
-      it " returns the value of the deleted key" do
-        @agent.memory = { foo: "baz"}
+      it "returns the string value of the deleted key" do
+        @agent.memory = { foo: "baz" }
         @agent.options['code'] = 'Agent.check = function() {
           this.createEvent({ message: this.deleteKey("foo")});
           };'
         @agent.save!
         @agent.check
         created_event = @agent.events.last
-        expect(created_event.payload).to eq({ 'message' => "baz" })
+        expect(created_event.payload).to eq('message' => "baz")
+      end
+
+      it "returns the hash value of the deleted key" do
+        @agent.memory = { foo: { baz: 'test' }  }
+        @agent.options['code'] = 'Agent.check = function() {
+          this.createEvent({ message: this.deleteKey("foo")});
+          };'
+        @agent.save!
+        @agent.check
+        created_event = @agent.events.last
+        expect(created_event.payload).to eq('message' => { 'baz' => 'test' })
       end
     end
 


### PR DESCRIPTION
This PR adds a deleteKey function to the Javascript Agent. The function deletes a key from the agent memory and returns the value of the key. 