### PR TITLE
Fix `this.memory(key, falsy)` not working in JavaScriptAgent

### DIFF
--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -114,12 +114,9 @@ module Agents
       context["getOptions"] = lambda { |a, x| interpolated.to_json }
       context["doLog"] = lambda { |a, x| log x }
       context["doError"] = lambda { |a, x| error x }
-      context["getMemory"] = lambda do |a, x, y|
-        if x && y
-          memory[x] = clean_nans(y)
-        else
-          memory.to_json
-        end
+      context["getMemory"] = lambda { |a| memory.to_json }
+      context["setMemory"] = lambda do |a, x, y|
+        memory[x] = clean_nans(y)
       end
       context["deleteKey"] = lambda { |a, x| memory.delete(x).to_json }
       context["escapeHtml"] = lambda { |a, x| CGI.escapeHTML(x) }
@@ -168,7 +165,7 @@ module Agents
 
         Agent.memory = function(key, value) {
           if (typeof(key) !== "undefined" && typeof(value) !== "undefined") {
-            getMemory(key, value);
+            setMemory(key, value);
           } else if (typeof(key) !== "undefined") {
             return JSON.parse(getMemory())[key];
           } else {

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -186,6 +186,30 @@ describe Agents::JavaScriptAgent do
         @agent.save!
         expect { @agent.reload.memory }.not_to raise_error
       end
+
+      it "it stores null" do
+        @agent.options['code'] = 'Agent.check = function() {
+          this.memory("foo", "test");
+          this.memory("foo", null);
+          };'
+        @agent.save!
+        @agent.check
+        expect(@agent.memory['foo']).to eq(nil)
+        @agent.save!
+        expect { @agent.reload.memory }.not_to raise_error
+      end
+
+      it "it stores false" do
+        @agent.options['code'] = 'Agent.check = function() {
+          this.memory("foo", "test");
+          this.memory("foo", false);
+          };'
+        @agent.save!
+        @agent.check
+        expect(@agent.memory['foo']).to eq(false)
+        @agent.save!
+        expect { @agent.reload.memory }.not_to raise_error
+      end
     end
 
     describe "deleteKey" do


### PR DESCRIPTION
cf. https://github.com/cantino/huginn/pull/1543#issuecomment-226285977