### PR TITLE
Return to Agent Events after Event show

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -32,7 +32,7 @@
             <td class='payload'><%= truncate event.payload.to_json, :length => 90, :omission => "" %></td>
             <td>
               <div class="btn-group btn-group-xs">
-                <%= link_to 'Show', event_path(event), class: "btn btn-default" %>
+                <%= link_to 'Show', event_path(event, return: request.fullpath), class: "btn btn-default" %>
                 <%= link_to 'Re-emit', reemit_event_path(event), method: :post, data: { confirm: 'Are you sure you want to duplicate this event and emit the new one now?' }, class: "btn btn-default" %>
                 <%= link_to 'Delete', event_path(event), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-default" %>
               </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -49,7 +49,7 @@
 
       <br />
       <div class="btn-group">
-        <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, events_path, class: "btn btn-default" %>
+        <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, filtered_agent_return_link || events_path, class: "btn btn-default" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
In agents/:id/events i click show an event. When i then click back i return to all events in /events and not the filtered events for the agent. 

In the PR the User gets back to the events of the agents using the filtered_agent_return_link  helper. 