### PR TITLE
Docker images: fix sudo swallowing env variables

### DIFF
--- a/docker/multi-process/scripts/init
+++ b/docker/multi-process/scripts/init
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export LC_ALL=en_US.UTF-8
+
 cd /app
 
 # Cleanup any leftover pid file
@@ -46,7 +48,7 @@ echo "RAILS_SERVE_STATIC_FILES=true" >> .env
 
 chmod ugo+r /app/.env
 source /app/.env
-sudo -u huginn -H bundle install --without test development --path vendor/bundle
+sudo -u huginn -H -E bundle install --without test development --path vendor/bundle
 
 # use default port number if it is still not set
 case "${DATABASE_ADAPTER}" in

--- a/docker/scripts/setup
+++ b/docker/scripts/setup
@@ -20,6 +20,7 @@ RAILS_ENV=production APP_SECRET_TOKEN=secret DATABASE_ADAPTER=sqlite3 ON_HEROKU=
 # Bundle again to get rid of the sqlite3 gem
 cp Gemfile.bak Gemfile
 RAILS_ENV=production APP_SECRET_TOKEN=secret DATABASE_ADAPTER=sqlite3 ON_HEROKU=true bundle install --without test development --path vendor/bundle -j 4
+chown huginn:huginn Gemfile.lock
 
 # Configure the unicorn server
 mv config/unicorn.rb.example config/unicorn.rb

--- a/docker/single-process/scripts/init
+++ b/docker/single-process/scripts/init
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export LC_ALL=en_US.UTF-8
+
 cd /app
 
 # Configure database based on linked container
@@ -40,18 +42,18 @@ case "${DATABASE_ADAPTER}" in
   *) echo "Unsupported database adapter. Available adapters are mysql2, and postgresql." && exit 1 ;;
 esac
 
-sudo -u huginn -H bundle install --without test development --path vendor/bundle
+sudo -u huginn -H -E bundle install --without test development --path vendor/bundle
 
 if [ -z $1 ]; then
-  sudo -u huginn -H bundle exec rake db:create db:migrate RAILS_ENV=${RAILS_ENV}
+  sudo -u huginn -H -E bundle exec rake db:create db:migrate RAILS_ENV=${RAILS_ENV}
 fi
 
 if [[ -z "${DO_NOT_SEED}" && -z $1 ]]; then
-  sudo -u huginn -H bundle exec rake db:seed RAILS_ENV=${RAILS_ENV}
+  sudo -u huginn -H -E bundle exec rake db:seed RAILS_ENV=${RAILS_ENV}
 fi
 
 if [ -z $1 ]; then
-  exec sudo -u huginn -H bundle exec unicorn -c config/unicorn.rb
+  exec sudo -u huginn -H -E bundle exec unicorn -c config/unicorn.rb
 else
-  exec sudo -u huginn -H bundle exec rails runner "$@" RAILS_ENV=${RAILS_ENV}
+  exec sudo -u huginn -H -E bundle exec rails runner "$@" RAILS_ENV=${RAILS_ENV}
 fi


### PR DESCRIPTION
Adds the -E argument to sudo calls which passes the environment to the called command. Ensures env variables which are not defined with default in .env.example are available in Huginn.
Fixes encoding issue when loading agent gems which contain non ASCII characters.