### PR TITLE
allow decimal values to be shown on the peak graph

### DIFF
--- a/app/assets/stylesheets/agent_views/peak_detector_agent/show.css.scss
+++ b/app/assets/stylesheets/agent_views/peak_detector_agent/show.css.scss
@@ -1,7 +1,7 @@
 .show-view.peak-detector-agent,
 .show-view.twitter-stream-agent {
   .rickshaw_annotation_timeline {
-    left: 40px;
+    left: 60px;
     width: 700px;
   }
 
@@ -28,7 +28,7 @@
 
       .chart {
         position: relative;
-        left: 40px;
+        left: 60px;
         overflow: hidden;
         width: 700px;
       }
@@ -60,7 +60,7 @@
         position: absolute;
         top: 0;
         bottom: 0;
-        width: 40px;
+        width: 60px;
       }
     }
   }

--- a/app/views/agents/agent_views/peak_detector_agent/_show.html.erb
+++ b/app/views/agents/agent_views/peak_detector_agent/_show.html.erb
@@ -17,7 +17,7 @@
       <script>
         $(function() {
           var $chart = $(".chart-container.group-<%= index.to_s %>").last();
-          var data = <%= Utils.jsonify(data.map {|count, time| { :x => time.to_i, :y => count.to_i } }) %>;
+          var data = <%= Utils.jsonify(data.select {|c, _t| !c.nil? }.map {|count, time| { :x => time.to_i, :y => count.to_f } }) %>;
           var peaks = <%= Utils.jsonify((@agent.memory[:peaks] && @agent.memory[:peaks][group_name]) || []) %>;
           var name = <%= Utils.jsonify(group_name) %>;
 


### PR DESCRIPTION
I found that the peak detector graph was not good at displaying smaller numbers (it couldn't show decimal places, so make it useless for things like forex rates). So it can show decimal values now, but had to adjust the styling of the chart as the X axis was not wide enough. Nil values are also excluded from display.