### PR TITLE
Add setMemory function to Javascript Agent

### DIFF
--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -21,7 +21,7 @@ module Agents
       * `this.memory()`
       * `this.memory(key)`
       * `this.memory(keyToSet, valueToSet)`
-      * `this.setMemory(object)` (sets the memory to the values of the input object)
+      * `this.setMemory(object)` (replaces the Agent's memory with the provided object)
       * `this.deleteKey(key)` (deletes a key from memory and returns the value)
       * `this.credential(name)`
       * `this.credential(name, valueToSet)`
@@ -116,7 +116,7 @@ module Agents
       context["doLog"] = lambda { |a, x| log x }
       context["doError"] = lambda { |a, x| error x }
       context["getMemory"] = lambda { |a| memory.to_json }
-      context["setKey"] = lambda do |a, x, y|
+      context["setMemoryKey"] = lambda do |a, x, y|
         memory[x] = clean_nans(y)
       end
       context["setMemory"] = lambda do |a, x|
@@ -169,7 +169,7 @@ module Agents
 
         Agent.memory = function(key, value) {
           if (typeof(key) !== "undefined" && typeof(value) !== "undefined") {
-            setKey(key, value);
+            setMemoryKey(key, value);
           } else if (typeof(key) !== "undefined") {
             return JSON.parse(getMemory())[key];
           } else {

--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -21,6 +21,7 @@ module Agents
       * `this.memory()`
       * `this.memory(key)`
       * `this.memory(keyToSet, valueToSet)`
+      * `this.setMemory(object)` (sets the memory to the values of the input object)
       * `this.deleteKey(key)` (deletes a key from memory and returns the value)
       * `this.credential(name)`
       * `this.credential(name, valueToSet)`
@@ -115,8 +116,11 @@ module Agents
       context["doLog"] = lambda { |a, x| log x }
       context["doError"] = lambda { |a, x| error x }
       context["getMemory"] = lambda { |a| memory.to_json }
-      context["setMemory"] = lambda do |a, x, y|
+      context["setKey"] = lambda do |a, x, y|
         memory[x] = clean_nans(y)
+      end
+      context["setMemory"] = lambda do |a, x|
+        memory.replace(clean_nans(x))
       end
       context["deleteKey"] = lambda { |a, x| memory.delete(x).to_json }
       context["escapeHtml"] = lambda { |a, x| CGI.escapeHTML(x) }
@@ -165,12 +169,16 @@ module Agents
 
         Agent.memory = function(key, value) {
           if (typeof(key) !== "undefined" && typeof(value) !== "undefined") {
-            setMemory(key, value);
+            setKey(key, value);
           } else if (typeof(key) !== "undefined") {
             return JSON.parse(getMemory())[key];
           } else {
             return JSON.parse(getMemory());
           }
+        }
+
+        Agent.setMemory = function(obj) {
+          setMemory(obj);
         }
 
         Agent.credential = function(name, value) {

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -212,6 +212,22 @@ describe Agents::JavaScriptAgent do
       end
     end
 
+    describe "setMemory" do
+      it "stores an object" do
+        @agent.options['code'] = 'Agent.check = function() {
+          var u = {};
+          u["one"] = 1;
+          u["two"] = 2;
+          this.setMemory(u);
+          };'
+        @agent.save!
+        @agent.check
+        expect(@agent.memory).to eq({ "one" => 1, "two" => 2 })
+        @agent.save!
+        expect { @agent.reload.memory }.not_to raise_error
+      end
+    end
+
     describe "deleteKey" do
       it "deletes a memory key" do
         @agent.memory = { foo: "baz" }


### PR DESCRIPTION
Sorry for the delay this PR addresses #1527. I think there is a better solution but i'm not sure which way to go with this.memory
 
If this.memory is adjusted you have this.memory(object) setting the memory and this.memory(key) getting a value from memory which i find confusing. 

Introducing new functions like setMemory and getMemory would bring some code duplication for backward compability. 