### PR TITLE
Make HttpStatusAgent provide redirect info

### DIFF
--- a/app/models/agents/http_status_agent.rb
+++ b/app/models/agents/http_status_agent.rb
@@ -82,7 +82,8 @@ module Agents
 
       # Deal with failures
       if measured_result.result
-        payload.merge!({ 'response_received' => true, 'status' => current_status })
+        final_url = boolify(interpolated['disable_redirect_follow']) ? url : measured_result.result.to_hash[:url]
+        payload.merge!({ 'final_url' => final_url, 'redirected' => (url != final_url), 'response_received' => true, 'status' => current_status })
         # Deal with headers
         if local_headers.present?
           header_results = measured_result.result.headers.select {|header, value| local_headers.include?(header)}

--- a/spec/controllers/http_status_agent_spec.rb
+++ b/spec/controllers/http_status_agent_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
+class MockResponse < Struct.new(:status, :headers, :url)
+  alias_method :to_hash, :to_h
+end
+
 describe 'HttpStatusAgent' do
 
   let(:agent) do
@@ -36,9 +40,6 @@ describe 'HttpStatusAgent' do
 
                        def f.set url, response, time = nil
                          sleep(time/1000) if time
-                         def response.to_hash
-                           to_h
-                         end
                          programmed_responses[url] = response
                        end
                      end
@@ -112,7 +113,7 @@ describe 'HttpStatusAgent' do
       let(:header_value) { SecureRandom.uuid }
 
       let(:event_with_a_successful_ping) do
-        agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(status_code, {}, successful_url))
+        agent.faraday.set(successful_url, MockResponse.new(status_code, {}, successful_url))
         Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: "" } }
       end
 
@@ -224,7 +225,7 @@ describe 'HttpStatusAgent' do
       describe "but the ping returns a status code of 0" do
 
         let(:event_with_a_successful_ping) do
-          agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(0, {}, successful_url))
+          agent.faraday.set(successful_url, MockResponse.new(0, {}, successful_url))
           Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: "" } }
         end
 
@@ -254,7 +255,7 @@ describe 'HttpStatusAgent' do
       describe "but the ping returns a status code of -1" do
 
         let(:event_with_a_successful_ping) do
-          agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(-1, {}, successful_url))
+          agent.faraday.set(successful_url, MockResponse.new(-1, {}, successful_url))
           Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: "" } }
         end
 
@@ -315,7 +316,7 @@ describe 'HttpStatusAgent' do
 
       describe "with a header specified" do
         let(:event_with_a_successful_ping) do
-          agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(status_code, {header => header_value}, successful_url))
+          agent.faraday.set(successful_url, MockResponse.new(status_code, {header => header_value}, successful_url))
           Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: header } }
         end
 
@@ -331,7 +332,7 @@ describe 'HttpStatusAgent' do
         let(:nonexistant_header) { SecureRandom.uuid }
 
         let(:event_with_a_successful_ping) do
-          agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(status_code, {header => header_value}, successful_url))
+          agent.faraday.set(successful_url, MockResponse.new(status_code, {header => header_value}, successful_url))
           Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: header + "," + nonexistant_header } }
         end
 

--- a/spec/controllers/http_status_agent_spec.rb
+++ b/spec/controllers/http_status_agent_spec.rb
@@ -36,6 +36,9 @@ describe 'HttpStatusAgent' do
 
                        def f.set url, response, time = nil
                          sleep(time/1000) if time
+                         def response.to_hash
+                           to_h
+                         end
                          programmed_responses[url] = response
                        end
                      end

--- a/spec/controllers/http_status_agent_spec.rb
+++ b/spec/controllers/http_status_agent_spec.rb
@@ -109,7 +109,7 @@ describe 'HttpStatusAgent' do
       let(:header_value) { SecureRandom.uuid }
 
       let(:event_with_a_successful_ping) do
-        agent.faraday.set(successful_url, Struct.new(:status, :headers).new(status_code, {}))
+        agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(status_code, {}, successful_url))
         Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: "" } }
       end
 
@@ -208,10 +208,20 @@ describe 'HttpStatusAgent' do
         expect(agent.the_created_events[0][:payload]['url']).to eq(successful_url)
       end
 
+      it "should return the final url" do
+        agent.receive events
+        expect(agent.the_created_events[0][:payload]['final_url']).to eq(successful_url)
+      end
+
+      it "should return whether the url redirected" do
+        agent.receive events
+        expect(agent.the_created_events[0][:payload]['redirected']).to eq(false)
+      end
+
       describe "but the ping returns a status code of 0" do
 
         let(:event_with_a_successful_ping) do
-          agent.faraday.set(successful_url, Struct.new(:status, :headers).new(0, {}))
+          agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(0, {}, successful_url))
           Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: "" } }
         end
 
@@ -241,7 +251,7 @@ describe 'HttpStatusAgent' do
       describe "but the ping returns a status code of -1" do
 
         let(:event_with_a_successful_ping) do
-          agent.faraday.set(successful_url, Struct.new(:status, :headers).new(-1, {}))
+          agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(-1, {}, successful_url))
           Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: "" } }
         end
 
@@ -302,7 +312,7 @@ describe 'HttpStatusAgent' do
 
       describe "with a header specified" do
         let(:event_with_a_successful_ping) do
-          agent.faraday.set(successful_url, Struct.new(:status, :headers).new(status_code, {header => header_value}))
+          agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(status_code, {header => header_value}, successful_url))
           Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: header } }
         end
 
@@ -318,7 +328,7 @@ describe 'HttpStatusAgent' do
         let(:nonexistant_header) { SecureRandom.uuid }
 
         let(:event_with_a_successful_ping) do
-          agent.faraday.set(successful_url, Struct.new(:status, :headers).new(status_code, {header => header_value}))
+          agent.faraday.set(successful_url, Struct.new(:status, :headers, :url).new(status_code, {header => header_value}, successful_url))
           Event.new.tap { |e| e.payload = { url: successful_url, headers_to_save: header + "," + nonexistant_header } }
         end
 


### PR DESCRIPTION
This is just a small change to make HttpStatusAgent provide info on what the final, post-redirections URL was for a given request, and a boolean representing whether or not it redirected or not.

Specs are failing. Here's the problem: for some reason, `measured_result.result.to_hash[:url]` throws an exception in the RSpec environment, saying that `to_hash` isn't a method, and did I mean `to_h`. Changing the code to `measured_result.result.to_h[:url]` completely fixes the specs, but breaks in the actual Rails environment with a similar exception (`to_h` isn't a method, did you mean `to_hash`). So I'm not sure how to solve that one.