### PR TITLE
Monkey patch faraday to fix encoding issue in URLs

### DIFF
--- a/config/initializers/faraday_patch.rb
+++ b/config/initializers/faraday_patch.rb
@@ -1,0 +1,11 @@
+# Monkey patch https://github.com/lostisland/faraday/pull/513
+# Fixes encoding issue when passing an URL with non UTF-8 characters
+module Faraday
+  module Utils
+    def unescape(s)
+      string = s.to_s
+      string.force_encoding(Encoding::BINARY) if RUBY_VERSION >= '1.9'
+      CGI.unescape string
+    end
+  end
+end


### PR DESCRIPTION
Using binary encoding allows the URL to contain characters that are not UTF-8 encoded.

 #1588