### PR TITLE
Added api_key option to UserLocationAgent

### DIFF
--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -14,6 +14,8 @@ module Agents
       If you want to only keep more precise locations, set `max_accuracy` to the upper bound, in meters. The default name for this field is `accuracy`, but you can change this by setting a value for `accuracy_field`.
 
       If you want to require a certain distance traveled, set `min_distance` to the minimum distance, in meters. Note that GPS readings and the measurement itself aren't exact, so don't rely on this for precision filtering.
+
+      To view the locations on a map, set `api_key` to your Google Maps JavaScript API key.
     MD
     end
 
@@ -42,6 +44,7 @@ module Agents
         'secret' => SecureRandom.hex(7),
         'max_accuracy' => '',
         'min_distance' => '',
+        'api_key' => '',
       }
     end
 

--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -15,7 +15,7 @@ module Agents
 
       If you want to require a certain distance traveled, set `min_distance` to the minimum distance, in meters. Note that GPS readings and the measurement itself aren't exact, so don't rely on this for precision filtering.
 
-      To view the locations on a map, set `api_key` to your Google Maps JavaScript API key.
+      To view the locations on a map, set `api_key` to your [Google Maps JavaScript API key](https://developers.google.com/maps/documentation/javascript/get-api-key#key).
     MD
     end
 

--- a/app/views/agents/agent_views/user_location_agent/_show.html.erb
+++ b/app/views/agents/agent_views/user_location_agent/_show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head do -%>
-<%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?sensor=false" %>
+<%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@agent.options[:api_key]}" %>
 <%= javascript_include_tag "map_marker" %>
 <% end -%>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,7 +20,7 @@
 
       <% if @event.lat && @event.lng %>
         <% content_for :head do -%>
-<%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?sensor=false" %>
+<%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@event.agent.options[:api_key]}" %>
 <%= javascript_include_tag "map_marker" %>
         <% end -%>
 

--- a/spec/models/agents/user_location_agent_spec.rb
+++ b/spec/models/agents/user_location_agent_spec.rb
@@ -6,7 +6,8 @@ describe Agents::UserLocationAgent do
                                   :name => 'something',
                                   :options => { :secret => 'my_secret',
                                     :max_accuracy => '50',
-                                    :min_distance => '50' })
+                                    :min_distance => '50',
+                                    :api_key => 'api_key' })
     @agent.save!
   end
 


### PR DESCRIPTION
The `api_key` is used on the summary page of the UserLocationAgent
as well as the event detail page to display a location on a Google
Map which requires an API key. Closes #1612