### PR TITLE
Docker: fix usage of ENV variables that are not in .env.example

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,7 +79,7 @@ Huginn::Application.configure do
 
   config.action_mailer.default_url_options = { :host => ENV['DOMAIN'] }
   config.action_mailer.asset_host = ENV['DOMAIN']
-  if ENV['ASSET_HOST']
+  if ENV['ASSET_HOST'].present?
     config.action_mailer.asset_host = ENV['ASSET_HOST']
   end
   config.action_mailer.perform_deliveries = true

--- a/db/seeds/seeder.rb
+++ b/db/seeds/seeder.rb
@@ -1,14 +1,14 @@
 class Seeder
   def self.seed
-    user = User.find_or_initialize_by(:email => ENV['SEED_EMAIL'] || "admin@example.com")
+    user = User.find_or_initialize_by(:email => ENV['SEED_EMAIL'].presence || "admin@example.com")
     if user.persisted?
       puts "User with email '#{user.email}' already exists, not seeding."
       exit
     end
 
-    user.username = ENV['SEED_USERNAME'] || "admin"
-    user.password = ENV['SEED_PASSWORD'] || "password"
-    user.password_confirmation = ENV['SEED_PASSWORD'] || "password"
+    user.username = ENV['SEED_USERNAME'].presence || "admin"
+    user.password = ENV['SEED_PASSWORD'].presence || "password"
+    user.password_confirmation = ENV['SEED_PASSWORD'].presence || "password"
     user.invitation_code = User::INVITATION_CODES.first
     user.admin = true
     user.save!

--- a/docker/scripts/setup
+++ b/docker/scripts/setup
@@ -27,3 +27,16 @@ mv config/unicorn.rb.example config/unicorn.rb
 sed -ri 's/^listen .*$/listen ENV["PORT"]/' config/unicorn.rb
 sed -ri 's/^stderr_path.*$//' config/unicorn.rb
 sed -ri 's/^stdout_path.*$//' config/unicorn.rb
+
+# Add ENV variables to .env.example which are not present in it but usable
+cat >> /app/.env.example <<EOF
+ASSET_HOST=
+DEFAULT_SCENARIO_FILE=
+RAILS_SERVE_STATIC_FILES=
+SEED_EMAIL=
+SEED_PASSWORD=
+SEED_USERNAME=
+SMTP_OPENSSL_CA_FILE=
+SMTP_OPENSSL_CA_PATH=
+SMTP_OPENSSL_VERIFY_MODE=
+EOF


### PR DESCRIPTION
Variables that are usable but not present with default values in .env.example were located with this one-liner:

```
diff  --changed-group-format='%<' --unchanged-group-format='' <(ack "ENV\[.(.+?).\]" --output='$1' -h app config lib db| sort | uniq) <(grep = .env.example | sed -e 's/^#\([^ ]\)/\1/' | grep -v -e '^#'| ack "(.+?)=" --output='$1'|sort)
```

The docker containers [use .env.example](https://github.com/cantino/huginn/blob/master/docker/single-process/scripts/init#L25) to select the environment variables which are written to `.env` on startup. Appending the additional variables during the image build makes them usable later.