### PR TITLE
Allow TwitterUserAgent to retry failed actions

### DIFF
--- a/db/migrate/20160823151303_set_emit_error_event_for_twitter_action_agents.rb
+++ b/db/migrate/20160823151303_set_emit_error_event_for_twitter_action_agents.rb
@@ -1,0 +1,15 @@
+class SetEmitErrorEventForTwitterActionAgents < ActiveRecord::Migration
+  def up
+    Agents::TwitterActionAgent.find_each do |agent|
+      agent.options['emit_error_events'] = 'true'
+      agent.save!(validate: false)
+    end
+  end
+
+  def down
+    Agents::TwitterActionAgent.find_each do |agent|
+      agent.options.delete('emit_error_events')
+      agent.save!(validate: false)
+    end
+  end
+end


### PR DESCRIPTION
Add new `emit_error_events` option which is set to `false` for all new `TwitterActionAgent`s. This will ensure the Agent is retried when the action failed by raising an exception.

For all existing `TwitterUserAgent`s the option is set to `true` to keep the previous behavior.

#1191