### PR TITLE
Admin "become" method

### DIFF
--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -22,5 +22,8 @@
 <div class="row">
   <div class="col-md-12">
     <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, admin_users_path, class: "btn btn-default" %>
+    <% if @user.persisted? %>
+      <%= link_to 'Become User', switch_to_user_admin_user_path(@user), class: "btn btn-default btn-info", data: { confirm: 'This will log you in as another user. Would you like to continue?' } %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -24,12 +24,13 @@
               <td><%= link_to user.username, edit_admin_user_path(user) %></td>
               <td><%= user.email %></td>
               <td><%= user_account_state(user) %></td>
-              <td><%= user.agents.active.count %></td>
-              <td><%= user.agents.inactive.count %></td>
+              <td><%= link_to user.agents.active.count, switch_to_user_admin_user_path(user), data: { confirm: 'This will log you in as another user. Would you like to continue?' } %></td>
+              <td><%= link_to user.agents.inactive.count, switch_to_user_admin_user_path(user), data: { confirm: 'This will log you in as another user. Would you like to continue?' } %></td>
               <td title='<%= user.created_at %>'><%= time_ago_in_words user.created_at %> ago</td>
               <td>
                 <div class="btn-group btn-group-xs">
                   <% if user != current_user %>
+                    <%= link_to 'Become User', switch_to_user_admin_user_path(user), class: "btn btn-default", data: { confirm: 'This will log you in as another user. Would you like to continue?' } %>
                     <% if user.active? %>
                       <%= link_to 'Deactivate', deactivate_admin_user_path(user), method: :put, class: "btn btn-default" %>
                     <% else %>

--- a/app/views/agents/index.html.erb
+++ b/app/views/agents/index.html.erb
@@ -2,7 +2,7 @@
   <div class='row'>
     <div class='col-md-12'>
       <div class="page-header">
-        <h2>Your Agents</h2>
+        <h2><%= session[:original_admin_user_id].present? ? "#{current_user.username}’s Agents" : 'Your Agents' %></h2>
       </div>
 
       <%= render 'agents/table' %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -60,9 +60,17 @@
     <li class="dropdown">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">
         Account
+        <% if user_signed_in? && session[:original_admin_user_id].present? %>
+          <span class="label label-warning"><%= current_user.username %></span>
+        <% end %>
         <b class="caret"></b>
       </a>
       <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
+        <% if user_signed_in? && session[:original_admin_user_id].present? %>
+          <li>
+            <%= link_to 'Switch Back to Admin User', switch_back_admin_users_path, tabindex: '-1' %>
+          </li>
+        <% end %>
         <li>
           <% if user_signed_in? %>
             <%= link_to 'Account', edit_user_registration_path, :tabindex => "-1" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,10 @@ Huginn::Application.routes.draw do
       member do
         put :deactivate
         put :activate
+        get :switch_to_user
+      end
+      collection do
+        get :switch_back
       end
     end
   end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -19,4 +19,41 @@ describe Admin::UsersController do
       end
     end
   end
+
+  describe 'GET #switch_to_user' do
+    it "switches to another user" do
+      sign_in users(:jane)
+
+      get :switch_to_user, :id => users(:bob).id
+      expect(response).to redirect_to(agents_path)
+      expect(subject.session[:original_admin_user_id]).to eq(users(:jane).id)
+    end
+
+    it "does not switch if not admin" do
+      sign_in users(:bob)
+
+      get :switch_to_user, :id => users(:jane).id
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe 'GET #switch_back' do
+    it "switches to another user and back" do
+      sign_in users(:jane)
+
+      get :switch_to_user, :id => users(:bob).id
+      expect(response).to redirect_to(agents_path)
+      expect(subject.session[:original_admin_user_id]).to eq(users(:jane).id)
+
+      get :switch_back
+      expect(response).to redirect_to(admin_users_path)
+      expect(subject.session[:original_admin_user_id]).to be_nil
+    end
+
+    it "does not switch_back without having switched" do
+      sign_in users(:bob)
+      get :switch_back
+      expect(response).to redirect_to(root_path)
+    end
+  end
 end


### PR DESCRIPTION
One part of https://github.com/cantino/huginn/pull/1593

Adds the following routes to allow an admin user to temporarily become another user and then switch back. And some UI for doing that.

```
switch_user_admin_user GET                 /admin/users/:id/switch_user(.:format)                   admin/users#switch_user
switch_back_admin_users GET                 /admin/users/switch_back(.:format)                       admin/users#switch_back
```

