### PR TITLE
Fix SMTP config regression when not using authentication

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -4,8 +4,8 @@ ActionMailer::Base.smtp_settings = {
   domain: ENV['SMTP_DOMAIN'],
   authentication: ENV['SMTP_AUTHENTICATION'] || "plain",
   enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true',
-  user_name: ENV['SMTP_USER_NAME'] || "",
-  password: ENV['SMTP_PASSWORD'] || "",
+  user_name: ENV['SMTP_USER_NAME'].presence,
+  password: ENV['SMTP_PASSWORD'].presence,
   openssl_verify_mode: ENV['SMTP_OPENSSL_VERIFY_MODE'].presence,
   ca_path: ENV['SMTP_OPENSSL_CA_PATH'].presence,
   ca_file: ENV['SMTP_OPENSSL_CA_FILE'].presence


### PR DESCRIPTION
`user_name` and `password` need to be set to nil when no authentication should be performed

Fixes #1657