### PR TITLE
Add cache_response option to completable form fields

### DIFF
--- a/app/assets/javascripts/components/form_configurable.js.coffee
+++ b/app/assets/javascripts/components/form_configurable.js.coffee
@@ -53,10 +53,13 @@ $ ->
     updateDropdownData = (form_data, element, data) ->
       returnedResults[form_data.attribute] = {text: 'Options', children: data}
       $(element).trigger('change')
+      $("input[role~=completable]").off 'select2-opening', select2OpeningCallback
       $(element).select2('open')
+      $("input[role~=completable]").on 'select2-opening', select2OpeningCallback
 
-    $("input[role~=completable]").on 'select2-open', (e) ->
+    select2OpeningCallback = (e) ->
       form_data = getFormData(e.currentTarget)
+      delete returnedResults[form_data.attribute] if returnedResults[form_data.attribute] && !$(e.currentTarget).data('cacheResponse')
       return if returnedResults[form_data.attribute]
 
       $.ajax '/agents/complete',
@@ -66,6 +69,8 @@ $ ->
           updateDropdownData(form_data, e.currentTarget, data)
         error: (data) ->
           updateDropdownData(form_data, e.currentTarget, [{id: undefined, text: 'Error loading data.'}])
+
+    $("input[role~=completable]").on 'select2-opening', select2OpeningCallback
 
     $("input[type=radio][role~=form-configurable]").change (e) ->
       input = $(e.currentTarget).parents().siblings("input[data-attribute=#{$(e.currentTarget).data('attribute')}]")

--- a/app/concerns/form_configurable.rb
+++ b/app/concerns/form_configurable.rb
@@ -32,7 +32,7 @@ module FormConfigurable
       options = args.extract_options!.reverse_merge(roles: [], type: :string)
 
       if args.all? { |arg| arg.is_a?(Symbol) }
-        options.assert_valid_keys([:type, :roles, :values, :ace])
+        options.assert_valid_keys([:type, :roles, :values, :ace, :cache_response])
       end
 
       if options[:type] == :array && (options[:values].blank? || !options[:values].is_a?(Array))

--- a/app/presenters/form_configurable_agent_presenter.rb
+++ b/app/presenters/form_configurable_agent_presenter.rb
@@ -43,7 +43,7 @@ class FormConfigurableAgentPresenter < Decorator
         @view.concat(@view.text_field_tag "agent[options][#{attribute}]", value, html_options.merge(:class => "form-control #{@agent.send(:boolify, value) != nil ? 'hidden' : ''}"))
       end
     when :array, :string
-      @view.text_field_tag "agent[options][#{attribute}]", value, html_options.merge(:class => 'form-control')
+      @view.text_field_tag "agent[options][#{attribute}]", value, html_options.deep_merge(:class => 'form-control', data: {cache_response: data[:cache_response] != false})
     end
   end
 end


### PR DESCRIPTION
When `cache_response` is set to `false` for completable fields the returned options will not be cached on the client side. The default is `true`.

Clearing the cache is needed when the completable response depends on a different option of the Agent.

Usage Example:

```
form_configurable :models, roles: :completable, cache_response: false
```

* Disable the completion callback when `select2` is opened programmatically to avoid an infinite loop
* Moved the completion ajax call from `select2-open` to `select2-opening` to clear the cached results before
 `completableDefaultOptions` is called (shows the "Loading ..." message instead of the previous results)