### PR TITLE
bundle update net-ssh to 3.0.x (to avoid deprecation warn on Ruby 2.3)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,7 @@ GEM
     net-ftp-list (3.2.8)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
+    net-ssh (3.0.2)
     netrc (0.10.3)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)


### PR DESCRIPTION
```
ruby-2.3.1@huginn/gems/net-ssh-2.9.2/lib/net/ssh/transport/session.rb:67:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
ruby-2.3.1@huginn/gems/net-ssh-2.9.2/lib/net/ssh/transport/session.rb:84:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
```