### PR TITLE
`service_id` is a valid part of the agent_params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
     return {} unless params[:agent]
     @agent_params ||= begin
       options = params[:agent].delete(:options) if params[:agent][:options].present?
-      params[:agent].permit(:memory, :name, :type, :schedule, :disabled, :keep_events_for, :propagate_immediately, :drop_pending_events,
+      params[:agent].permit(:memory, :name, :type, :schedule, :disabled, :keep_events_for, :propagate_immediately, :drop_pending_events, :service_id,
                             source_ids: [], receiver_ids: [], scenario_ids: [], controller_ids: [], control_target_ids: []).tap do |agent_params|
         agent_params[:options] = options if options
       end

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -205,7 +205,7 @@ describe AgentsController do
 
     it "creates Agents and accepts specifing a target agent" do
       sign_in users(:bob)
-      attributes = valid_attributes
+      attributes = valid_attributes(service_id: 1)
       attributes[:receiver_ids] = attributes[:source_ids]
       expect {
         expect {


### PR DESCRIPTION
Fixes #1685