### PR TITLE
Ignore the fixture API key in WeatherAgent

### DIFF
--- a/app/models/agents/weather_agent.rb
+++ b/app/models/agents/weather_agent.rb
@@ -57,11 +57,11 @@ module Agents
     default_schedule "8pm"
 
     def working?
-      event_created_within?((interpolated['expected_update_period_in_days'].presence || 2).to_i) && !recent_error_logs?
+      event_created_within?((interpolated['expected_update_period_in_days'].presence || 2).to_i) && !recent_error_logs? && key_setup?
     end
 
     def key_setup?
-      interpolated['api_key'].present? && interpolated['api_key'] != "your-key"
+      interpolated['api_key'].present? && interpolated['api_key'] != "your-key" && interpolated['api_key'] != "put-your-key-here"
     end
 
     def default_options
@@ -102,7 +102,7 @@ module Agents
     def validate_options
       errors.add(:base, "service must be set to 'forecastio' or 'wunderground'") unless ["forecastio", "wunderground"].include?(weather_provider)
       errors.add(:base, "location is required") unless location.present?
-      errors.add(:base, "api_key is required") unless key_setup?
+      errors.add(:base, "api_key is required") unless interpolated['api_key'].present?
       errors.add(:base, "which_day selection is required") unless which_day.present?
     end
 

--- a/spec/models/agents/weather_agent_spec.rb
+++ b/spec/models/agents/weather_agent_spec.rb
@@ -19,6 +19,16 @@ describe Agents::WeatherAgent do
   it "creates a valid agent" do
     expect(agent).to be_valid
   end
+
+  it "is valid with put-your-key-here or your-key" do
+    agent.options['api_key'] = 'put-your-key-here'
+    expect(agent).to be_valid
+    expect(agent.working?).to be_falsey
+
+    agent.options['api_key'] = 'your-key'
+    expect(agent).to be_valid
+    expect(agent.working?).to be_falsey
+  end
   
   describe "#service" do
     it "doesn't have a Service object attached" do


### PR DESCRIPTION
Allow default WeatherAgent to be valid and savable even without a valid API key.