### PR TITLE
Rescue from AR:SubclassNotFound and allow to delete agents

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -208,6 +208,12 @@ class AgentsController < ApplicationController
     render json: @agent.complete_option(params[:attribute])
   end
 
+  def destroy_undefined
+    current_user.undefined_agents.destroy_all
+
+    redirect_back "All undefined Agents have been deleted."
+  end
+
   protected
 
   # Sanitize params[:return] to prevent open redirect attacks, a common security issue.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,12 @@ class ApplicationController < ActionController::Base
 
   helper :all
 
+  rescue_from 'ActiveRecord::SubclassNotFound' do
+    @undefined_agent_types = current_user.undefined_agent_types
+
+    render template: 'application/undefined_agents'
+  end
+
   def redirect_back(fallback_path, *args)
     redirect_to :back, *args
   rescue ActionController::RedirectBackError

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -113,4 +113,8 @@ module ApplicationHelper
 
     @highlighted_ranges.any? { |range| range.cover?(id) }
   end
+
+  def agent_type_to_human(type)
+    type.gsub(/^.*::/, '').underscore.humanize.titleize
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,4 +75,19 @@ class User < ActiveRecord::Base
   def requires_no_invitation_code?
     !!@requires_no_invitation_code
   end
+
+  def undefined_agent_types
+    agents.reorder('').group(:type).pluck(:type).select do |type|
+      begin
+        type.constantize
+        false
+      rescue NameError
+        true
+      end
+    end
+  end
+
+  def undefined_agents
+    agents.where(type: undefined_agent_types).select('id, schedule, type as undefined')
+  end
 end

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -25,7 +25,7 @@
           <% if @agent.new_record? %>
             <div class="form-group type-select">
               <%= f.label :type %>
-              <%= f.select :type, options_for_select([['Select an Agent Type', 'Agent', {title: ''}]] + Agent.types.map {|type| [type.name.gsub(/^.*::/, '').underscore.humanize.titleize, type, {title: h(Agent.build_for_type(type.name,current_user,{}).html_description.lines.first.strip)}] }, @agent.type), {}, :class => 'form-control' %>
+              <%= f.select :type, options_for_select([['Select an Agent Type', 'Agent', {title: ''}]] + Agent.types.map {|type| [agent_type_to_human(type.name), type, {title: h(Agent.build_for_type(type.name,current_user,{}).html_description.lines.first.strip)}] }, @agent.type), {}, :class => 'form-control' %>
             </div>
           <% end %>
         </div>

--- a/app/views/application/undefined_agents.html.erb
+++ b/app/views/application/undefined_agents.html.erb
@@ -1,0 +1,44 @@
+<div class="container">
+  <div class='row'>
+    <div class='col-md-12'>
+      <div class="page-header">
+        <h3>
+          <div class="alert alert-danger" role="alert">
+            Error: Agent(s) are 'missing in action'
+          </div>
+        </h3>
+      </div>
+      <blockquote>
+        <p>
+          You have one or more Agents registered in the database for which no corresponding definition is available in the source code:
+        </p>
+        <ul>
+          <% @undefined_agent_types.each do |type| %>
+            <li><%= agent_type_to_human(type) %></li>
+          <% end %>
+        </ul>
+        <br/>
+        <p>
+          The issue most probably occurred because of one or more of the following reasons:
+        </p>
+        <ul>
+          <li>If the respective Agent is distributed as a Ruby gem, it might have been removed from the <code>ADDITIONAL_GEMS</code> environment setting.</li>
+          <li>If the respective Agent is distributed as part of the Huginn application codebase, it might have been removed from that either on purpose (because the Agent has been deprecated or been moved to an Agent gem) or accidentally. Please check if the Agent(s) in question are available in your Huginn codebase under the path <code>app/models/agents/</code>.</li>
+        </ul>
+        <br/>
+        <p>
+          You can fix the issue by adding the Agent(s) back to the application codebase by
+        </p>
+        <ul>
+          <li>adding the respective Agent(s) to the the <code>ADDITIONAL_GEMS</code> environment setting. Please see <a href="https://github.com/cantino/huginn_agent" target="_blank">https://github.com/cantino/huginn_agent</a> for documentation on how to properly set it.</li>
+          <li>adding the respective Agent(s) code to the Huginn application codebase (in case it was deleted accidentally).</li>
+          <li>deleting the respective Agent(s) from the database using the button below.</li>
+        </ul>
+        <br/>
+        <div class="btn-group">
+          <%= link_to icon_tag('glyphicon-trash') + ' Delete Missing Agents', undefined_agents_path, class: "btn btn-danger", method: :DELETE, data: { confirm: 'Are you sure all missing Agents should be deleted from the database?'} %>
+        </div>
+      </blockquote>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Huginn::Application.routes.draw do
       get :event_descriptions
       post :validate
       post :complete
+      delete :undefined, action: :destroy_undefined
     end
 
     resources :logs, :only => [:index] do

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -434,4 +434,18 @@ describe AgentsController do
       expect(agent.reload.memory).to eq({ "test" => 42})
     end
   end
+
+  describe 'DELETE undefined' do
+    it 'removes an undefined agent from the database' do
+      sign_in users(:bob)
+      agent = agents(:bob_website_agent)
+      agent.update_attribute(:type, 'Agents::UndefinedAgent')
+      agent2 = agents(:jane_website_agent)
+      agent2.update_attribute(:type, 'Agents::UndefinedAgent')
+
+      expect {
+        delete :destroy_undefined
+      }.to change { Agent.count }.by(-1)
+    end
+  end
 end

--- a/spec/features/undefined_agents_spec.rb
+++ b/spec/features/undefined_agents_spec.rb
@@ -1,0 +1,21 @@
+require 'capybara_helper'
+
+describe "handling undefined agents" do
+  before do
+    login_as(users(:bob))
+    agent = agents(:bob_website_agent)
+    agent.update_attribute(:type, 'Agents::UndefinedAgent')
+  end
+
+  it 'renders the error page' do
+    visit agents_path
+    expect(page).to have_text("Error: Agent(s) are 'missing in action'")
+    expect(page).to have_text('Undefined Agent')
+  end
+
+  it 'deletes all undefined agents' do
+    visit agents_path
+    click_on('Delete Missing Agents')
+    expect(page).to have_text('Your Agents')
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe User do
+  let(:bob) { users(:bob) }
+
   describe "validations" do
     describe "invitation_code" do
       context "when configured to use invitation codes" do
@@ -62,6 +64,31 @@ describe User do
       agent.reload
       expect(agent.deactivated).to be_falsy
       expect(users(:bob).deactivated_at).to be_nil
+    end
+  end
+
+  context '#undefined_agent_types' do
+    it 'returns an empty array when no agents are undefined' do
+      expect(bob.undefined_agent_types).to be_empty
+    end
+
+    it 'returns the undefined agent types' do
+      agent = agents(:bob_website_agent)
+      agent.update_attribute(:type, 'Agents::UndefinedAgent')
+      expect(bob.undefined_agent_types).to match_array(['Agents::UndefinedAgent'])
+    end
+  end
+
+  context '#undefined_agents' do
+    it 'returns an empty array when no agents are undefined' do
+      expect(bob.undefined_agents).to be_empty
+    end
+
+    it 'returns the undefined agent types' do
+      agent = agents(:bob_website_agent)
+      agent.update_attribute(:type, 'Agents::UndefinedAgent')
+      expect(bob.undefined_agents).not_to be_empty
+      expect(bob.undefined_agents.first).to be_a(Agent)
     end
   end
 end


### PR DESCRIPTION
Especially when using Agent gems it happens that an Agent was deleted from the gem or the user removed a gem from the configuration. Instead of failing with an Internal Server Error the user now is offered to delete all undefined agents.

`type.constantize` is needed to invoke the Rails auto_loader in development since not all Agent classes are loaded when the application boots.

<img width="1170" alt="screenshot 2016-09-19 13 23 12" src="https://cloud.githubusercontent.com/assets/20943/18630341/4089d5c4-7e6c-11e6-9430-0a18e2858e24.png">