### PR TITLE
Replace jquery.serializeObject with new implementation

### DIFF
--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -36,7 +36,7 @@ class @AgentEditPage
       @handleTypeChange(true)
 
       # Update the dropdown to match agent description as well as agent name
-      $('#agent_type').select2
+      $('select#agent_type').select2
         width: 'resolve'
         formatResult: formatAgentForSelect
         escapeMarkup: (m) ->

--- a/spec/features/form_configurable_feature_spec.rb
+++ b/spec/features/form_configurable_feature_spec.rb
@@ -1,0 +1,10 @@
+require 'capybara_helper'
+
+describe "form configuring agents", js: true do
+  it 'completes fields with predefined array values' do
+    login_as(users(:bob))
+    visit edit_agent_path(agents(:bob_csv_agent))
+    check('Propagate immediately')
+    select2("serialize", from: "Mode")
+  end
+end

--- a/spec/fixtures/agents.yml
+++ b/spec/fixtures/agents.yml
@@ -139,6 +139,12 @@ bob_basecamp_agent:
   service: generic
   guid: <%= SecureRandom.hex %>
 
+bob_csv_agent:
+  type: Agents::CsvAgent
+  user: bob
+  name: "Bob's CsvAgent"
+  guid: <%= SecureRandom.hex %>
+
 jane_basecamp_agent:
   type: Agents::BasecampAgent
   user: jane


### PR DESCRIPTION
The old serializeObject function serialized checked checkboxes as an array which was not correct and with strong_parameters enabled it triggered a `UnpermittedParameters` error.

In the AgentEditPage javascript we only need to initialize `select2` when then `#agent_type` field is a select box (trying to call `select2` on normal text fields caused a javascript error in the feature specs)