### PR TITLE
Escape square brackets in urls

### DIFF
--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -25,7 +25,7 @@ module Utils
     begin
       URI(uri)
     rescue URI::Error
-      URI(uri.to_s.gsub(/[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,\[\]]+/) { |unsafe|
+      URI(uri.to_s.gsub(/[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,]+/) { |unsafe|
             unsafe.bytes.each_with_object(String.new) { |uc, s|
               s << sprintf('%%%02X', uc)
             }


### PR DESCRIPTION
I'm encountering instances of urls that use unescaped square brackets. This issue that is described well here: https://stackoverflow.com/questions/13013987/ruby-how-to-escape-url-with-square-brackets-and

This type of problem was solved in #958 and I've just added square brackets to the list of illegal characters to escape.