### PR TITLE
Fix escape characters of events when dry running

### DIFF
--- a/app/assets/javascripts/components/utils.js.coffee
+++ b/app/assets/javascripts/components/utils.js.coffee
@@ -69,7 +69,7 @@ class @Utils
               json = $(e.target).find('.payload-editor').val()
               json = '{}' if json == ''
               try
-                payload = JSON.parse(json)
+                payload = JSON.parse(json.replace(/\\\\([n|r|t])/g, "\\$1"))
                 throw true unless payload.constructor is Object
                 if Object.keys(payload).length == 0
                   json = ''

--- a/spec/features/dry_running_spec.rb
+++ b/spec/features/dry_running_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "Dry running an Agent", js: true do
+  let(:formatting_agent) { agents(:bob_formatting_agent) }
+  let(:user)    { users(:bob) }
+  let(:emitter) { agents(:bob_weather_agent) }
+
+  before(:each) do
+    login_as(user)
+  end
+
+  def open_dry_run_modal(agent)
+    visit edit_agent_path(agent)
+    click_on("Dry Run")
+    expect(page).to have_text('Event to send')
+  end
+
+  context 'successful dry runs' do
+    it 'sends escape characters correctly to the backend' do
+      emitter.events << Event.new(payload: {data: "Line 1\nLine 2\nLine 3"})
+      formatting_agent.sources << emitter
+      formatting_agent.options.merge!('instructions' => {'data' => "{{data | newline_to_br | strip_newlines | split: '<br />' | join: ','}}"})
+      formatting_agent.save!
+
+      open_dry_run_modal(formatting_agent)
+      find('.dry-run-event-sample').click
+      within(:css, '.modal .builder') do
+        expect(page).to have_text('Line 1\nLine 2\nLine 3')
+      end
+      click_on("Dry Run")
+      expect(page).to have_text('Line 1,Line 2,Line 3')
+      expect(page).to have_selector(:css, 'li[role="presentation"].active a[href="#tabEvents"]')
+    end
+  end
+end

--- a/spec/fixtures/agents.yml
+++ b/spec/fixtures/agents.yml
@@ -60,6 +60,14 @@ bob_weather_agent:
   keep_events_for: <%= 45.days %>
   options: <%= { :location => 94102, :lat => 37.779329, :lng => -122.41915, :api_key => 'test' }.to_json.inspect %>
 
+bob_formatting_agent:
+  type: Agents::EventFormattingAgent
+  user: bob
+  name: "Formatting Agent"
+  guid: <%= SecureRandom.hex %>
+  keep_events_for: <%= 45.days %>
+  options: <%= { instructions: {}, mode: 'clean' }.to_json.inspect %>
+
 jane_weather_agent:
   type: Agents::WeatherAgent
   user: jane

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,7 @@ require 'rspec/rails'
 require 'rr'
 require 'webmock/rspec'
 
-WebMock.disable_net_connect!
+WebMock.disable_net_connect!(allow_localhost: true)
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
JSONEditor double escapes escape characters to properly display them in the UI, however when dry running Agents we actually need to send the Event's characters as they were.
Before an event containing new lines like this `Line A\nLineB` would be send as `Line A\\nLineB` to the backend. By replacing the double escaped slashes we ensure the event is handled as it would be when not dry running.

 #1677