### PR TITLE
Add as_object Liquid filter

### DIFF
--- a/app/concerns/liquid_droppable.rb
+++ b/app/concerns/liquid_droppable.rb
@@ -18,6 +18,11 @@ module LiquidDroppable
         yield [name, __send__(name)]
       }
     end
+
+    def as_json
+      return {} unless defined?(self.class::METHODS)
+      Hash[self.class::METHODS.map { |m| [m, send(m).as_json]}]
+    end
   end
 
   included do
@@ -33,12 +38,10 @@ module LiquidDroppable
     self.class::Drop.new(self)
   end
 
-  class MatchDataDrop < Liquid::Drop
-    def initialize(object)
-      @object = object
-    end
+  class MatchDataDrop < Drop
+    METHODS = %w[pre_match post_match names size]
 
-    %w[pre_match post_match names size].each { |attr|
+    METHODS.each { |attr|
       define_method(attr) {
         @object.__send__(attr)
       }
@@ -64,7 +67,9 @@ module LiquidDroppable
   require 'uri'
 
   class URIDrop < Drop
-    URI::Generic::COMPONENT.each { |attr|
+    METHODS = URI::Generic::COMPONENT
+
+    METHODS.each { |attr|
       define_method(attr) {
         @object.__send__(attr)
       }

--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -92,7 +92,9 @@ module LiquidInterpolatable
 
   def interpolate_string(string, self_object = nil)
     interpolate_with(self_object) do
-      Liquid::Template.parse(string).render!(interpolation_context)
+      catch :as_object do
+        Liquid::Template.parse(string).render!(interpolation_context)
+      end
     end
   end
 
@@ -223,6 +225,25 @@ module LiquidInterpolatable
     # Serializes data as JSON
     def json(input)
       JSON.dump(input)
+    end
+
+    # Returns a Ruby object
+    #
+    # It can be used as a JSONPath replacement for Agents that only support Liquid:
+    #
+    # Event:   {"something": {"nested": {"data": 1}}}
+    # Liquid:  {{something.nested | as_object}}
+    # Returns: {"data": 1}
+    #
+    # Splitting up a string with Liquid filters and return the Array:
+    #
+    # Event:   {"data": "A,B,C"}}
+    # Liquid:  {{data | split: ',' | as_object}}
+    # Returns: ['A', 'B', 'C']
+    #
+    # as_object ALWAYS has be the last filter in a Liquid expression!
+    def as_object(object)
+      throw :as_object, object.as_json
     end
 
     private

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -443,7 +443,7 @@ class AgentDrop
     @object.short_type
   end
 
-  [
+  METHODS = [
     :name,
     :type,
     :options,
@@ -456,7 +456,9 @@ class AgentDrop
     :disabled,
     :keep_events_for,
     :propagate_immediately,
-  ].each { |attr|
+  ]
+
+  METHODS.each { |attr|
     define_method(attr) {
       @object.__send__(attr)
     } unless method_defined?(attr)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -119,4 +119,8 @@ class EventDrop
   def _location_
     @object.location
   end
+
+  def as_json
+    {location: _location_.as_json, agent: @object.agent.to_liquid.as_json, payload: @payload.as_json, created_at: created_at.as_json}
+  end
 end


### PR DESCRIPTION
The `as_object` returns the received data/object as is without casting it to a string like liquid normally does. It can be used as a JSONPath replacement or to emit result of a Liquid filter chain as an array.

`catch` and `throw` needs to be used to break out of Liquid render chain. Liquid aggregates the output of every expression an array and [joins](https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/block.rb#L147) it together that join makes it impossible to get anything else than a string out of a Liquid template.

#1647
#1127