### PR TITLE
PushoverAgent: Treat parameter options as templates rather than default values

### DIFF
--- a/app/models/agents/pushover_agent.rb
+++ b/app/models/agents/pushover_agent.rb
@@ -12,26 +12,24 @@ module Agents
 
       **You need a Pushover API Token:** [https://pushover.net/apps/build](https://pushover.net/apps/build)
 
-      **You must provide** a `message` or `text` key that will contain the body of the notification. This can come from an event or be set as a default. Pushover API has a `512` Character Limit including `title`. `message` will be truncated.
-
       * `token`: your application's API token
       * `user`: the user or group key (not e-mail address).
       * `expected_receive_period_in_days`:  is maximum number of days that you would expect to pass between events being received by this agent.
 
-      Your event can provide any of the following optional parameters or you can provide defaults:
+      The following options are all Liquid templates which evaluated values will be posted to Pushover API.  Only the `message` parameter is required, and if it is blank API call is omitted.
 
+      Pushover API has a `512` Character Limit including `title`.  `message` will be truncated.
+
+      * `message` - your message (required)
       * `device` - your user's device name to send the message directly to that device, rather than all of the user's devices
       * `title` or `subject` - your notification's title
       * `url` - a supplementary URL to show with your message - `512` Character Limit
       * `url_title` - a title for your supplementary URL, otherwise just the URL is shown - `100` Character Limit
+      * `timestamp` - a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) of your message's date and time to display to the user, rather than the time your message is received by the Pushover API.
       * `priority` - send as `-1` to always send as a quiet notification, `0` is default, `1` to display as high-priority and bypass the user's quiet hours, or `2` for emergency priority: [Please read Pushover Docs on Emergency Priority](https://pushover.net/api#priority)
       * `sound` - the name of one of the sounds supported by device clients to override the user's default sound choice. [See PushOver docs for sound options.](https://pushover.net/api#sounds)
       * `retry` - Required for emergency priority - Specifies how often (in seconds) the Pushover servers will send the same notification to the user. Minimum value: `30`
       * `expire` - Required for emergency priority - Specifies how many seconds your notification will continue to be retried for (every retry seconds). Maximum value: `86400`
-
-      Your event can also pass along a timestamp parameter:
-
-      * `timestamp` - a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) of your message's date and time to display to the user, rather than the time your message is received by the Pushover API.
 
     MD
 
@@ -39,15 +37,16 @@ module Agents
       {
         'token' => '',
         'user' => '',
-        'message' => 'a default message',
-        'device' => '',
-        'title' => '',
-        'url' => '',
-        'url_title' => '',
-        'priority' => '0',
-        'sound' => 'pushover',
-        'retry' => '0',
-        'expire' => '0',
+        'message' => '{{ message }}',
+        'device' => '{{ device }}',
+        'title' => '{{ title }}',
+        'url' => '{{ url }}',
+        'url_title' => '{{ url_title }}',
+        'priority' => '{{ priority }}',
+        'timestamp' => '{{ timestamp }}',
+        'sound' => '{{ sound }}',
+        'retry' => '{{ retry }}',
+        'expire' => '{{ expire }}',
         'expected_receive_period_in_days' => '1'
       }
     end
@@ -60,37 +59,42 @@ module Agents
 
     def receive(incoming_events)
       incoming_events.each do |event|
-        payload_interpolated = interpolated(event)
-        message = (event.payload['message'].presence || event.payload['text'].presence || payload_interpolated['message']).to_s
-        if message.present?
-          post_params = {
-            'token' => payload_interpolated['token'],
-            'user' => payload_interpolated['user'],
-            'message' => message
-          }
+        interpolate_with(event) do
+          post_params = {}
 
-          post_params['device'] = event.payload['device'].presence || payload_interpolated['device']
-          post_params['title'] = event.payload['title'].presence || event.payload['subject'].presence || payload_interpolated['title']
+          # required parameters
+          %w[
+            token
+            user
+            message
+          ].all? { |key|
+            if value = String.try_convert(interpolated[key].presence)
+              post_params[key] = value
+            end
+          } or next
 
-          url = (event.payload['url'].presence || payload_interpolated['url'] || '').to_s
-          url = url.slice 0..512
-          post_params['url'] = url
-
-          url_title = (event.payload['url_title'].presence || payload_interpolated['url_title']).to_s
-          url_title = url_title.slice 0..100
-          post_params['url_title'] = url_title
-
-          post_params['priority'] = (event.payload['priority'].presence || payload_interpolated['priority']).to_i
-
-          if event.payload.has_key? 'timestamp'
-            post_params['timestamp'] = (event.payload['timestamp']).to_s
+          # optional parameters
+          %w[
+            device
+            title
+            url
+            url_title
+            priority
+            timestamp
+            sound
+            retry
+            expire
+          ].each do |key|
+            if value = String.try_convert(interpolated[key].presence)
+              case key
+              when 'url'
+                value.slice!(512..-1)
+              when 'url_title'
+                value.slice!(100..-1)
+              end
+              post_params[key] = value
+            end
           end
-
-          post_params['sound'] = (event.payload['sound'].presence || payload_interpolated['sound']).to_s
-
-          post_params['retry'] = (event.payload['retry'].presence || payload_interpolated['retry']).to_i
-
-          post_params['expire'] = (event.payload['expire'].presence || payload_interpolated['expire']).to_i
 
           send_notification(post_params)
         end
@@ -102,7 +106,7 @@ module Agents
     end
 
     def send_notification(post_params)
-      response = HTTParty.post(API_URL, :query => post_params)
+      response = HTTParty.post(API_URL, query: post_params)
       puts response
     end
   end

--- a/app/models/agents/pushover_agent.rb
+++ b/app/models/agents/pushover_agent.rb
@@ -16,7 +16,7 @@ module Agents
       * `user`: the user or group key (not e-mail address).
       * `expected_receive_period_in_days`:  is maximum number of days that you would expect to pass between events being received by this agent.
 
-      The following options are all Liquid templates which evaluated values will be posted to Pushover API.  Only the `message` parameter is required, and if it is blank API call is omitted.
+      The following options are all Liquid templates whose evaluated values will be posted to the Pushover API.  Only the `message` parameter is required, and if it is blank API call is omitted.
 
       Pushover API has a `512` Character Limit including `title`.  `message` will be truncated.
 

--- a/db/migrate/20161004120214_update_pushover_agent_options.rb
+++ b/db/migrate/20161004120214_update_pushover_agent_options.rb
@@ -1,0 +1,58 @@
+class UpdatePushoverAgentOptions < ActiveRecord::Migration
+  DEFAULT_OPTIONS = {
+    'message' => '{{ message | default: text }}',
+    'device' => '{{ device }}',
+    'title' => '{{ title | default: subject }}',
+    'url' => '{{ url }}',
+    'url_title' => '{{ url_title }}',
+    'priority' => '{{ priority }}',
+    'timestamp' => '{{ timestamp }}',
+    'sound' => '{{ sound }}',
+    'retry' => '{{ retry }}',
+    'expire' => '{{ expire }}',
+  }
+
+  def up
+    Agents::PushoverAgent.find_each do |agent|
+      options = agent.options
+      DEFAULT_OPTIONS.each_pair do |key, default|
+        current = options[key]
+
+        options[key] =
+          if current.blank?
+            default
+          else
+            "#{prefix_for(key)}#{current}#{suffix_for(key)}"
+          end
+      end
+      agent.save!(validate: false)
+    end
+  end
+
+  def down
+    Agents::PushoverAgent.transaction do
+      Agents::PushoverAgent.find_each do |agent|
+        options = agent.options
+        DEFAULT_OPTIONS.each_pair do |key, default|
+          current = options[key]
+
+          options[key] =
+            if current == default
+              ''
+            else
+              current[/\A#{Regexp.quote(prefix_for(key))}(.*)#{Regexp.quote(suffix_for(key))}\z/, 1]
+            end or raise ActiveRecord::IrreversibleMigration, "Cannot revert migration once Pushover agents are configured"
+        end
+        agent.save!(validate: false)
+      end
+    end
+  end
+
+  def prefix_for(key)
+    "{% capture _default_ %}"
+  end
+
+  def suffix_for(key)
+    "{% endcapture %}" << DEFAULT_OPTIONS[key].sub(/(?=\}\}\z)/, '| default: _default_ ')
+  end
+end

--- a/spec/models/agents/pushover_agent_spec.rb
+++ b/spec/models/agents/pushover_agent_spec.rb
@@ -2,27 +2,29 @@ require 'rails_helper'
 
 describe Agents::PushoverAgent do
   before do
-    @checker = Agents::PushoverAgent.new(:name => 'Some Name',
-                                       :options => { :token => 'x',
-                                                :user => 'x',
-                                                :message => 'Some Message',
-                                                :device => 'Some Device',
-                                                :title => 'Some Message Title',
-                                                :url => 'http://someurl.com',
-                                                :url_title => 'Some Url Title',
-                                                :priority => 0,
-                                                :timestamp => 'false',
-                                                :sound => 'pushover',
-                                                :retry => 0,
-                                                :expire => 0,
-                                                :expected_receive_period_in_days => '1'})
-     
+    @checker = Agents::PushoverAgent.new(name: 'Some Name',
+                                         options: {
+                                           token: 'x',
+                                           user: 'x',
+                                           message: "{{ message | default: text | default: 'Some Message' }}",
+                                           device: "{{ device | default: 'Some Device' }}",
+                                           title: "{{ title | default: 'Some Message Title' }}",
+                                           url: "{{ url | default: 'http://someurl.com' }}",
+                                           url_title: "{{ url_title | default: 'Some Url Title' }}",
+                                           priority: "{{ priority | default: 0 }}",
+                                           timestamp: "{{ timestamp | default: 'false' }}",
+                                           sound: "{{ sound | default: 'pushover' }}",
+                                           retry: "{{ retry | default: 0 }}",
+                                           expire: "{{ expire | default: 0 }}",
+                                           expected_receive_period_in_days: '1'
+                                         })
+
     @checker.user = users(:bob)
     @checker.save!
 
     @event = Event.new
     @event.agent = agents(:bob_weather_agent)
-    @event.payload = { :message => 'Looks like its going to rain' }
+    @event.payload = { message: 'Looks like its going to rain' }
     @event.save!
 
     @sent_notifications = []
@@ -33,12 +35,12 @@ describe Agents::PushoverAgent do
     it 'should make sure multiple events are being received' do
       event1 = Event.new
       event1.agent = agents(:bob_rain_notifier_agent)
-      event1.payload = { :message => 'Some message' }
+      event1.payload = { message: 'Some message' }
       event1.save!
 
       event2 = Event.new
       event2.agent = agents(:bob_weather_agent)
-      event2.payload = { :message => 'Some other message' }
+      event2.payload = { message: 'Some other message' }
       event2.save!
 
       @checker.receive([@event,event1,event2])
@@ -50,7 +52,7 @@ describe Agents::PushoverAgent do
     it 'should make sure event message overrides default message' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some new message'}
+      event.payload = { message: 'Some new message'}
       event.save!
 
       @checker.receive([event])
@@ -60,7 +62,7 @@ describe Agents::PushoverAgent do
     it 'should make sure event text overrides default message' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :text => 'Some new text'}
+      event.payload = { text: 'Some new text'}
       event.save!
 
       @checker.receive([event])
@@ -70,7 +72,7 @@ describe Agents::PushoverAgent do
     it 'should make sure event title overrides default title' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some message', :title => 'Some new title' }
+      event.payload = { message: 'Some message', title: 'Some new title' }
       event.save!
 
       @checker.receive([event])
@@ -80,7 +82,7 @@ describe Agents::PushoverAgent do
     it 'should make sure event url overrides default url' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some message', :url => 'Some new url' }
+      event.payload = { message: 'Some message', url: 'Some new url' }
       event.save!
 
       @checker.receive([event])
@@ -90,7 +92,7 @@ describe Agents::PushoverAgent do
     it 'should make sure event url_title overrides default url_title' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some message', :url_title => 'Some new url_title' }
+      event.payload = { message: 'Some message', url_title: 'Some new url_title' }
       event.save!
 
       @checker.receive([event])
@@ -100,17 +102,17 @@ describe Agents::PushoverAgent do
     it 'should make sure event priority overrides default priority' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some message', :priority => 1 }
+      event.payload = { message: 'Some message', priority: '1' }
       event.save!
 
       @checker.receive([event])
-      expect(@sent_notifications[0]['priority']).to eq(1)
+      expect(@sent_notifications[0]['priority']).to eq('1')
     end
 
     it 'should make sure event timestamp overrides default timestamp' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some message', :timestamp => 'false' }
+      event.payload = { message: 'Some message', timestamp: 'false' }
       event.save!
 
       @checker.receive([event])
@@ -120,7 +122,7 @@ describe Agents::PushoverAgent do
     it 'should make sure event sound overrides default sound' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some message', :sound => 'Some new sound' }
+      event.payload = { message: 'Some message', sound: 'Some new sound' }
       event.save!
 
       @checker.receive([event])
@@ -130,21 +132,21 @@ describe Agents::PushoverAgent do
     it 'should make sure event retry overrides default retry' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some message', :retry => 1 }
+      event.payload = { message: 'Some message', retry: 1 }
       event.save!
 
       @checker.receive([event])
-      expect(@sent_notifications[0]['retry']).to eq(1)
+      expect(@sent_notifications[0]['retry']).to eq('1')
     end
 
     it 'should make sure event expire overrides default expire' do
       event = Event.new
       event.agent = agents(:bob_rain_notifier_agent)
-      event.payload = { :message => 'Some message', :expire => 60 }
+      event.payload = { message: 'Some message', expire: '60' }
       event.save!
 
       @checker.receive([event])
-      expect(@sent_notifications[0]['expire']).to eq(60)
+      expect(@sent_notifications[0]['expire']).to eq('60')
     end
   end
 
@@ -158,7 +160,7 @@ describe Agents::PushoverAgent do
       expect(@checker.reload).to be_working
       two_days_from_now = 2.days.from_now
       stub(Time).now { two_days_from_now }
-      
+
       # More time has passed than the expected receive period without any new events
       expect(@checker.reload).not_to be_working
     end


### PR DESCRIPTION
This should fix #1718.

While at it, character limit implementation is fixed: `slice(0..n)` would take the first n+1 characters instead of n.