### PR TITLE
Update documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-# Ruby 2.0 is the minimum requirement
-ruby ['2.0.0', RUBY_VERSION].max
+# Ruby 2.2.2 is the minimum requirement
+ruby ['2.2.2', RUBY_VERSION].max
 
 # Load vendored dotenv gem and .env file
 require File.join(File.dirname(__FILE__), 'lib/gemfile_helper.rb')
@@ -116,7 +116,6 @@ gem 'rufus-scheduler', '~> 3.0.8', require: false
 gem 'sass-rails',   '~> 5.0.6'
 gem 'select2-rails', '~> 3.5.4'
 gem 'spectrum-rails'
-gem 'string-scrub'	# for ruby <2.1
 gem 'therubyracer', '~> 0.12.2'
 gem 'typhoeus', '~> 0.6.3'
 gem 'uglifier', '~> 2.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,7 +527,6 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    string-scrub (0.0.5)
     systemu (2.6.4)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
@@ -685,7 +684,6 @@ DEPENDENCIES
   spring (~> 1.7.2)
   spring-commands-rspec (~> 1.0.4)
   spring-watcher-listen (~> 2.0.0)
-  string-scrub
   therubyracer (~> 0.12.2)
   tumblr_client!
   twilio-ruby (~> 3.11.5)

--- a/doc/README.md
+++ b/doc/README.md
@@ -8,7 +8,7 @@
 
 ### Manual installation
 
-Manual installation instructions which will guide through the steps to install Huginn on any Ubuntu 12.04/14.04 or Debian 6/7 server.
+Manual installation instructions which will guide through the steps to install Huginn on any Ubuntu 12.04/14.04/16.04 or Debian 6/7 server.
 
 - [Install](manual/README.md) Requirements, directory structures and installation from source.
 - [Update](manual/update.md) Update your installation.

--- a/doc/deployment/capistrano/deploy.rb
+++ b/doc/deployment/capistrano/deploy.rb
@@ -68,7 +68,7 @@ namespace :foreman do
 end
 
 # If you want to use rvm on your server and have it maintained by Capistrano, uncomment these lines:
-#   set :rvm_ruby_string, '2.0.0@huginn'
+#   set :rvm_ruby_string, '2.3.1@huginn'
 #   set :rvm_type, :user
 #   before 'deploy', 'rvm:install_rvm'
 #   before 'deploy', 'rvm:install_ruby'

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -65,8 +65,8 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2 | tar xj
-    cd ruby-2.3.0
+    curl -L --progress http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2 | tar xj
+    cd ruby-2.3.1
     ./configure --disable-install-rdoc
     make -j`nproc`
     sudo make install

--- a/doc/manual/requirements.md
+++ b/doc/manual/requirements.md
@@ -4,7 +4,7 @@
 
 ### Supported Unix distributions by this guide
 
-- Ubuntu (14.04 and 12.04)
+- Ubuntu (16.04, 14.04 and 12.04)
 - Debian (Jessie and Wheezy)
 
 ### Unsupported Unix distributions
@@ -27,7 +27,7 @@ Please consider using a virtual machine to run Huginn on Windows.
 
 ## Ruby versions
 
-Huginn requires Ruby (MRI) 2.0, 2.1 or 2.2
+Huginn requires Ruby (MRI) 2.2 or 2.3.
 You will have to use the standard MRI implementation of Ruby.
 We love [JRuby](http://jruby.org/) and [Rubinius](http://rubini.us/) but Huginn needs several Gems that have native extensions.
 


### PR DESCRIPTION
Ruby > 2.2 is now required
Manual installation guide works on Ubuntu 16.04
Remove obsolete `string-scrub` gem