### PR TITLE
Agent form: ace-editor highlighting and theme

### DIFF
--- a/app/assets/javascripts/ace.js.coffee
+++ b/app/assets/javascripts/ace.js.coffee
@@ -2,3 +2,7 @@
 #= require ace/mode-javascript.js
 #= require ace/mode-markdown.js
 #= require ace/mode-coffee.js
+#= require ace/mode-sql.js
+#= require ace/mode-json.js
+#= require ace/mode-yaml.js
+#= require ace/mode-text.js

--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -177,20 +177,28 @@ class @AgentEditPage
   buildAce: ->
     $(".ace-editor").each ->
       unless $(this).data('initialized')
-        $(this).data('initialized', true)
-        $source = $($(this).data('source')).hide()
+        $this = $(this)
+        $this.data('initialized', true)
+        $source = $($this.data('source')).hide()
         editor = ace.edit(this)
-        $(this).data('ace-editor', editor)
+        $this.data('ace-editor', editor)
         session = editor.getSession()
         session.setTabSize(2)
         session.setUseSoftTabs(true)
         session.setUseWrapMode(false)
 
         setSyntax = ->
-          switch $("[name='agent[options][language]']").val()
-            when 'JavaScript' then session.setMode("ace/mode/javascript")
-            when 'CoffeeScript' then session.setMode("ace/mode/coffee")
-            else session.setMode("ace/mode/text")
+          if mode = $this.data('mode')
+            session.setMode("ace/mode/" + mode)
+
+          if theme = $this.data('theme')
+            editor.setTheme("ace/theme/" + theme);
+
+          if mode = $("[name='agent[options][language]']").val()
+            switch mode
+              when 'JavaScript' then session.setMode("ace/mode/javascript")
+              when 'CoffeeScript' then session.setMode("ace/mode/coffee")
+              else session.setMode("ace/mode/" + mode)
 
         $("[name='agent[options][language]']").on 'change', setSyntax
         setSyntax()

--- a/app/presenters/form_configurable_agent_presenter.rb
+++ b/app/presenters/form_configurable_agent_presenter.rb
@@ -23,7 +23,9 @@ class FormConfigurableAgentPresenter < Decorator
       @view.content_tag 'div' do
         @view.concat @view.text_area_tag("agent[options][#{attribute}]", value, html_options.merge(class: 'form-control', rows: 3))
         if data[:ace].present?
-          @view.concat @view.content_tag('div', '', class: 'ace-editor', data: { source: "[name='agent[options][#{attribute}]']" })
+          ace_options = { source: "[name='agent[options][#{attribute}]']", mode: '', theme: ''}.deep_symbolize_keys!
+          ace_options.deep_merge!(data[:ace].deep_symbolize_keys) if data[:ace].is_a?(Hash)
+          @view.concat @view.content_tag('div', '', class: 'ace-editor', data: ace_options)
         end
       end
     when :boolean


### PR DESCRIPTION
аce-editor mode (syntax highlighting) and theme customization was added.

Usage:
```ruby
 form_configurable :sql, type: :text, ace: {:mode =>'sql', :theme => 'sqlserver'}
```
```ruby
 form_configurable :sql, type: :text, ace: {:mode =>'yaml'}
```

```ruby
 form_configurable :sql, type: :text, ace: {:mode =>'json'}
``` 
You can try it in action with built in javascript_agent or pluggable [mysql2_agent:](https://github.com/yubuylov/huginn_mysql2_agent)

Add this to your configuration:
[Docker installation] (https://github.com/cantino/huginn/tree/master/docker):
```yaml
# docker env
environment:
  ADDITIONAL_GEMS: 'huginn_mysql2_agent(git: https://github.com/yubuylov/huginn_mysql2_agent.git)'
```
[Local installation] (https://github.com/cantino/huginn#local-installation):
```ruby 
# .env (Local huginn installation)
ADDITIONAL_GEMS=huginn_mysql2_agent(github: yubuylov/huginn_mysql2_agent)
```