### PR TITLE
Rss agent dynamic cleanup

### DIFF
--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -164,7 +164,6 @@ module Agents
         false
       else
         memory['seen_ids'].unshift entry_id
-        #~ memory['seen_ids'].pop if memory['seen_ids'].length > 500
         true
       end
     end

--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -107,7 +107,7 @@ module Agents
       end
 
       if options['max_ids'].present? && options['max_ids'].to_i < 1
-        errors.add(:base, "Please provide 'max_ids' as a positive number bigger then 0 indicating how many IDs should be saved to distinguish between new and old IDs in RSS feeds. Delete option to use default (500).")
+        errors.add(:base, "Please provide 'max_ids' as a number bigger than 0 indicating how many IDs should be saved to distinguish between new and old IDs in RSS feeds. Delete option to use default (500).")
       end
 
       validate_web_request_options!
@@ -165,9 +165,7 @@ module Agents
         false
       else
         memory['seen_ids'].unshift entry_id
-        while memory['seen_ids'].length > ((interpolated['max_ids'].presence || 500).to_i) do
-          memory['seen_ids'].pop
-        end
+		memory['seen_ids'].pop(memory['seen_ids'].length - ((options['max_ids'].presence || 500).to_i)) if memory['seen_ids'].length > ((options['max_ids'].presence || 500).to_i)
         true
       end
     end

--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -151,16 +151,20 @@ module Agents
           end
         end
       end
+      memory['seen_ids'].slice!(new_events.count, memory['seen_ids'].count - new_events.count)#~ cut the old ids off of the stack
       log "Fetched #{urls.to_sentence} and created #{created_event_count} event(s)."
     end
 
     def check_and_track(entry_id)
       memory['seen_ids'] ||= []
-      if memory['seen_ids'].include?(entry_id)
+      index = memory['seen_ids'].index(entry_id)
+      if index != nil
+	memory['seen_ids'].delete_at(index)#~ stack beahviour. Put each ID from the 'new_events' on top, even if it has already existed. Will result in old not used IDs to end up at the bottom of the stack
+	memory['seen_ids'].unshift entry_id
         false
       else
         memory['seen_ids'].unshift entry_id
-        memory['seen_ids'].pop if memory['seen_ids'].length > 500
+        #~ memory['seen_ids'].pop if memory['seen_ids'].length > 500
         true
       end
     end

--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -151,7 +151,9 @@ module Agents
           end
         end
       end
-      memory['seen_ids'].slice!(new_events.count, memory['seen_ids'].count - new_events.count)#~ cut the old ids off of the stack
+      if(memory['seen_ids'])#~if fetching fails first time or is empty, array does not exist yet
+        memory['seen_ids'].slice!(new_events.count, memory['seen_ids'].count - new_events.count)#~ cut the old ids off of the stack
+      end
       log "Fetched #{urls.to_sentence} and created #{created_event_count} event(s)."
     end
 

--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -169,7 +169,7 @@ module Agents
         false
       else
         memory['seen_ids'].unshift entry_id
-		    memory['seen_ids'].pop(memory['seen_ids'].length - remembered_id_count) if memory['seen_ids'].length > remembered_id_count
+        memory['seen_ids'].pop(memory['seen_ids'].length - remembered_id_count) if memory['seen_ids'].length > remembered_id_count
         true
       end
     end

--- a/spec/models/agents/rss_agent_spec.rb
+++ b/spec/models/agents/rss_agent_spec.rb
@@ -166,10 +166,10 @@ describe Agents::RssAgent do
       expect(agent.memory['seen_ids'][0]).to eq(newest_id)
     end
 
-    it "should truncate the seen_ids in memory at 500 items" do
+    it "should truncate the seen_ids in memory to the last seen items" do
       agent.memory['seen_ids'] = ['x'] * 490
       agent.check
-      expect(agent.memory['seen_ids'].length).to eq(500)
+      expect(agent.memory['seen_ids'].length).to eq(20)
     end
 
     it "should support an array of URLs" do

--- a/spec/models/agents/rss_agent_spec.rb
+++ b/spec/models/agents/rss_agent_spec.rb
@@ -166,10 +166,36 @@ describe Agents::RssAgent do
       expect(agent.memory['seen_ids'][0]).to eq(newest_id)
     end
 
-    it "should truncate the seen_ids in memory to the last seen items" do
+    it "should truncate the seen_ids in memory at 500 items per default" do
       agent.memory['seen_ids'] = ['x'] * 490
       agent.check
-      expect(agent.memory['seen_ids'].length).to eq(20)
+      expect(agent.memory['seen_ids'].length).to eq(500)
+    end
+    
+    it "should truncate the seen_ids in memory at amount of items configured in options" do
+      agent.options['max_ids'] = "600"
+      agent.memory['seen_ids'] = ['x'] * 590
+      agent.check
+      expect(agent.memory['seen_ids'].length).to eq(600)
+    end
+    
+    it "should truncate the seen_ids after configuring a lower limit of items when check is executed" do
+      agent.memory['seen_ids'] = ['x'] * 600
+      agent.options['max_ids'] = "400"
+      expect(agent.memory['seen_ids'].length).to eq(600)
+      agent.check
+      expect(agent.memory['seen_ids'].length).to eq(400)
+    end
+    
+    it "should truncate the seen_ids at default after removing custom limit" do
+      agent.options['max_ids'] = "600"
+      agent.memory['seen_ids'] = ['x'] * 590
+      agent.check
+      expect(agent.memory['seen_ids'].length).to eq(600)
+      
+      agent.options.delete('max_ids')
+      agent.check
+      expect(agent.memory['seen_ids'].length).to eq(500)
     end
 
     it "should support an array of URLs" do


### PR DESCRIPTION
Remove the fixed 500 IDs memory limit to allow longer/more RSS feeds.
Instead of a fixed limit, every ID that is no longer used in any of the RSS feeds will be removed from the memory.

I hit this limit since #1647 was fixed. My RSS agent is now setup with 87 feeds, each at 15 items max.

I copied this change to my setup and it works fine for now.
