### PR TITLE
WebsiteAgent can interpolate after extraction

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -189,6 +189,11 @@ module LiquidInterpolatable
       url
     end
 
+    # Rebase URIs contained in attributes in a given HTML fragment
+    def rebase_hrefs(input, base_uri)
+      Utils.rebase_hrefs(input, base_uri) rescue input
+    end
+
     # Unescape (basic) HTML entities in a string
     #
     # This currently decodes the following entities only: "&apos;",

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -134,7 +134,7 @@ module Agents
 
           * `headers`: Response headers; for example, `{{ _response_.headers.Content-Type }}` expands to the value of the Content-Type header.  Keys are insensitive to cases and -/_.
 
-          * `url`: The final URL of the fetched page, following redirects.
+          * `url`: The final URL of the fetched page, following redirects.  Using this in the `template` option, you can resolve relative URLs extracted from a document like `{{ link | to_uri: _request_.url }}` and `{{ content | rebase_hrefs: _request_.url }}`.
 
       # Ordering Events
 

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -124,13 +124,17 @@ module Agents
 
       # Liquid Templating
 
-      In Liquid templating, the following variable is available:
+      In Liquid templating, the following variables are available except when invoked by `data_from_event`:
+
+      * `_url_`: The URL specified to fetch the content from.
 
       * `_response_`: A response object with the following keys:
 
           * `status`: HTTP status as integer. (Almost always 200)
 
           * `headers`: Response headers; for example, `{{ _response_.headers.Content-Type }}` expands to the value of the Content-Type header.  Keys are insensitive to cases and -/_.
+
+          * `url`: The final URL of the fetched page, following redirects.
 
       # Ordering Events
 
@@ -328,6 +332,7 @@ module Agents
       raise "Failed: #{response.inspect}" unless consider_response_successful?(response)
 
       interpolation_context.stack {
+        interpolation_context['_url_'] = uri.to_s
         interpolation_context['_response_'] = ResponseDrop.new(response)
         handle_data(response.body, response.env[:url], existing_payload)
       }
@@ -602,6 +607,11 @@ module Agents
       # Integer value of HTTP status
       def status
         @object.status
+      end
+
+      # The URL
+      def url
+        @object.env.url.to_s
       end
     end
 

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -170,4 +170,93 @@ module Utils
       nil
     end
   end
+
+  module HTMLTransformer
+    SINGLE = 1
+    MULTIPLE = 2
+    COMMA_SEPARATED = 3
+    SRCSET = 4
+
+    URI_ATTRIBUTES = {
+      'a' => { 'href' => SINGLE },
+      'applet' => { 'archive' => COMMA_SEPARATED, 'codebase' => SINGLE },
+      'area' => { 'href' => SINGLE },
+      'audio' => { 'src' => SINGLE },
+      'base' => { 'href' => SINGLE },
+      'blockquote' => { 'cite' => SINGLE },
+      'body' => { 'background' => SINGLE },
+      'button' => { 'formaction' => SINGLE },
+      'command' => { 'icon' => SINGLE },
+      'del' => { 'cite' => SINGLE },
+      'embed' => { 'src' => SINGLE },
+      'form' => { 'action' => SINGLE },
+      'frame' => { 'longdesc' => SINGLE, 'src' => SINGLE },
+      'head' => { 'profile' => SINGLE },
+      'html' => { 'manifest' => SINGLE },
+      'iframe' => { 'longdesc' => SINGLE, 'src' => SINGLE },
+      'img' => { 'longdesc' => SINGLE, 'src' => SINGLE, 'srcset' => SRCSET, 'usemap' => SINGLE },
+      'input' => { 'formaction' => SINGLE, 'src' => SINGLE, 'usemap' => SINGLE },
+      'ins' => { 'cite' => SINGLE },
+      'link' => { 'href' => SINGLE },
+      'object' => { 'archive' => MULTIPLE, 'classid' => SINGLE, 'codebase' => SINGLE, 'data' => SINGLE, 'usemap' => SINGLE },
+      'q' => { 'cite' => SINGLE },
+      'script' => { 'src' => SINGLE },
+      'source' => { 'src' => SINGLE, 'srcset' => SRCSET },
+      'video' => { 'poster' => SINGLE, 'src' => SINGLE },
+    }
+
+    URI_ELEMENTS_XPATH = '//*[%s]' % URI_ATTRIBUTES.keys.map { |name| "name()='#{name}'" }.join(' or ')
+
+    module_function
+
+    def transform(html, &block)
+      block or raise ArgumentError, 'block must be given'
+
+      case html
+      when /\A\s*(?:<\?xml[\s?]|<!DOCTYPE\s)/i
+        doc = Nokogiri.parse(html)
+        yield doc
+        doc.to_s
+      when /\A\s*<(html|head|body)[\s>]/i
+        # Libxml2 automatically adds DOCTYPE and <html>, so we need to
+        # skip them.
+        element_name = $1
+        doc = Nokogiri::HTML::Document.parse(html)
+        yield doc
+        doc.at_xpath("//#{element_name}").xpath('self::node() | following-sibling::node()').to_s
+      else
+        doc = Nokogiri::HTML::Document.parse("<html><body>#{html}")
+        yield doc
+        doc.xpath("/html/body/node()").to_s
+      end
+    end
+
+    def replace_uris(html, &block)
+      block or raise ArgumentError, 'block must be given'
+
+      transform(html) { |doc|
+        doc.xpath(URI_ELEMENTS_XPATH).each { |element|
+          uri_attrs = URI_ATTRIBUTES[element.name] or next
+          uri_attrs.each { |name, format|
+            attr = element.attribute(name) or next
+            case format
+            when SINGLE
+              attr.value = block.call(attr.value.strip)
+            when MULTIPLE
+              attr.value = attr.value.gsub(/(\S+)/) { block.call($1) }
+            when COMMA_SEPARATED, SRCSET
+              attr.value = attr.value.gsub(/((?:\A|,)\s*)(\S+)/) { $1 + block.call($2) }
+            end
+          }
+        }
+      }
+    end
+  end
+
+  def self.rebase_hrefs(html, base_uri)
+    base_uri = normalize_uri(base_uri)
+    HTMLTransformer.replace_uris(html) { |url|
+      base_uri.merge(normalize_uri(url)).to_s
+    }
+  end
 end

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -323,4 +323,42 @@ describe LiquidInterpolatable::Filters do
       end
     end
   end
+
+  describe 'rebase_hrefs' do
+    let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
+
+    let(:fragment) { <<HTML }
+<ul>
+  <li>
+    <a href="downloads/file1"><img src="/images/iconA.png" srcset="/images/iconA.png 1x, /images/iconA@2x.png 2x">file1</a>
+  </li>
+  <li>
+    <a href="downloads/file2"><img src="/images/iconA.png" srcset="/images/iconA.png 1x, /images/iconA@2x.png 2x">file2</a>
+  </li>
+  <li>
+    <a href="downloads/file3"><img src="/images/iconB.png" srcset="/images/iconB.png 1x, /images/iconB@2x.png 2x">file3</a>
+  </li>
+</ul>
+HTML
+
+    let(:replaced_fragment) { <<HTML }
+<ul>
+  <li>
+    <a href="http://example.com/support/downloads/file1"><img src="http://example.com/images/iconA.png" srcset="http://example.com/images/iconA.png 1x, http://example.com/images/iconA@2x.png 2x">file1</a>
+  </li>
+  <li>
+    <a href="http://example.com/support/downloads/file2"><img src="http://example.com/images/iconA.png" srcset="http://example.com/images/iconA.png 1x, http://example.com/images/iconA@2x.png 2x">file2</a>
+  </li>
+  <li>
+    <a href="http://example.com/support/downloads/file3"><img src="http://example.com/images/iconB.png" srcset="http://example.com/images/iconB.png 1x, http://example.com/images/iconB@2x.png 2x">file3</a>
+  </li>
+</ul>
+HTML
+
+    it 'rebases relative URLs in a fragment' do
+      agent.interpolation_context['content'] = fragment
+      agent.options['template'] = "{{ content | rebase_hrefs: 'http://example.com/support/files.html' }}"
+      expect(agent.interpolated['template']).to eq(replaced_fragment)
+    end
+  end
 end

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -739,6 +739,22 @@ describe Agents::WebsiteAgent do
         expect(event.payload['response_info']).to eq('The reponse was 200 OK.')
       end
 
+      it "should be formatted by template after extraction" do
+        @valid_options['template'] = {
+          'url' => '{{url}}',
+          'title' => '{{title | upcase}}',
+          'summary' => '{{title}}: {{hovertext | truncate: 20}}',
+        }
+        @checker.options = @valid_options
+        @checker.check
+        event = Event.last
+        expect(event.payload).to eq({
+                                      'title' => 'EVOLVING',
+                                      'url' => 'http://imgs.xkcd.com/comics/evolving.png',
+                                      'summary' => 'Evolving: Biologists play r...',
+                                    })
+      end
+
       describe "XML" do
         before do
           stub_request(:any, /github_rss/).to_return(

--- a/spec/support/shared_examples/agent_controller_concern.rb
+++ b/spec/support/shared_examples/agent_controller_concern.rb
@@ -130,7 +130,10 @@ shared_examples_for AgentControllerConcern do
     end
 
     it "should configure targets with nested objects" do
-      agent.control_targets << agents(:bob_data_output_agent)
+      agent.control_targets = [
+        agents(:bob_basecamp_agent),  # does not support a `template` option, but anyway
+        agents(:bob_data_output_agent)
+      ]
       agent.options['action'] = 'configure'
       agent.options['configure_options'] = { 
         template: {


### PR DESCRIPTION
With this addition, user can format extracted data or compose new keys using Liquid without having to create an EventFormattingAgent, optionally making use of response header values.

New Liquid variables and a new Liquid filter allow user to resolve relative URLs in an extracted HTML fragment so that it can be used anywhere, such as when creating a feed using DataOutputAgent which contents are required to have absolute URLs.  The following configuration will "rebase" an HTML fragment extracted to the key `content` on the page URL:

```
"extract": {
  ...
  "content": { ... }
},
"interpolate": {
  "content": "{{ content | rebase_html: _request_.url }}"
}
```
