### PR TITLE
Improve encoding detection in WebsiteAgent

### DIFF
--- a/app/concerns/web_request_concern.rb
+++ b/app/concerns/web_request_concern.rb
@@ -46,6 +46,8 @@ module WebRequestConcern
             # Never try to transcode a binary content
             next
           end
+          # Return body as binary if default_encoding is nil
+          next if encoding.nil?
         end
         body.encode!(Encoding::UTF_8, encoding)
       end
@@ -89,6 +91,9 @@ module WebRequestConcern
     end
   end
 
+  # The default encoding for a text content with no `charset`
+  # specified in the Content-Type header.  Override this and make it
+  # return nil if you want to detect the encoding on your own.
   def default_encoding
     Encoding::UTF_8
   end


### PR DESCRIPTION
Previously, WebsiteAgent always assumed that a content with no charset specified in the Content-Type header would be encoded in UTF-8.  This enhancement is to make use of the encoding detector implemented in Nokogiri for HTML/XML documents, instead of blindly falling back to UTF-8.

When the document `type` is `html` or `xml`, WebsiteAgent tries to detect the encoding of a fetched document from the presence of a BOM, XML declaration, or HTML `meta` tag.

This fixes #1742.
