### PR TITLE
Added notes to the docs for timezones and env vars

### DIFF
--- a/docker/multi-process/README.md
+++ b/docker/multi-process/README.md
@@ -88,11 +88,27 @@ The `docker/multi-process` folder also has a `docker-compose.yml` that allows fo
 
     cd docker/multi-process ; docker-compose up
 
+__NOTE:__ If you have issues with huginn using the wrong system time you can mount the following volumes into the container:
+
+    ```
+    -v /etc/timezone:/etc/timezone \
+    -v /etc/localtime:/etc/localtime \
+
+    ```
+
 ## Environment Variables
 
 Other Huginn 12factored environment variables of note, as generated and put into the .env file as per Huginn documentation. All variables of the [.env.example](https://github.com/cantino/huginn/blob/master/.env.example) can be used to override the defaults which a read from the current `.env.example`.
 
 For variables in the .env.example that are commented out, the default is to not include that variable in the generated .env file.
+
+__NOTE:__ The following environent variables should be included in your `docker run` statement for improved security and right timing:
+
+    ```
+    -e TIMEZONE="Your timezone from rake time:zones:all" \
+    -e APP_SECRET_TOKEN=YourIndividualSecretToken \
+    -e INVITATION_CODE=YourIndividualInviteCode \
+    ```
 
 ## Building on your own
 

--- a/docker/single-process/README.md
+++ b/docker/single-process/README.md
@@ -73,11 +73,27 @@ Manual startup and linking to a MySQL container:
         -e DATABASE_PASSWORD=somethingsecret \
         cantino/huginn-single-process /scripts/init bin/threaded.rb
 
+__NOTE:__ If you have issues with huginn using the wrong system time you can mount the following volumes into the container:
+
+    ```
+    -v /etc/timezone:/etc/timezone \
+    -v /etc/localtime:/etc/localtime \
+
+    ```
+
 ## Environment Variables
 
 Other Huginn 12factored environment variables of note, as generated and put into the .env file as per Huginn documentation. All variables of the [.env.example](https://github.com/cantino/huginn/blob/master/.env.example) can be used to override the defaults which a read from the current `.env.example`.
 
 For variables in the .env.example that are commented out, the default is to not include that variable in the generated .env file.
+
+__NOTE:__ The following environent variables should be included in your `docker run` statement for improved security and right timing:
+
+    ```
+    -e TIMEZONE="Your timezone from rake time:zones:all" \
+    -e APP_SECRET_TOKEN=YourIndividualSecretToken \
+    -e INVITATION_CODE=YourIndividualInviteCode \
+    ```
 
 ## Building on your own
 


### PR DESCRIPTION
First of all, you've got a great documentation as of now.
I added some notes about the things i struggled with when i deployed huginn using docker.

These things were:
1. Issues with the container using the wrong timezone and hours/minutes
2. Telling the user that it's a good idea to change the secret token and invitation code to individual values.

One more thing that i wanted to write down but I didn't know where to put it was that when you set up huginn to send emails via gmail, you first have to let huginn gain access to the gmail account via http://www.google.com/accounts/DisplayUnlockCaptcha . Otherwise you'll get Net::SMTPAuthenticationError