### PR TITLE
Revert the special treatment for CDATA introduced in #1071

### DIFF
--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -558,14 +558,7 @@ module Agents
         case nodes
         when Nokogiri::XML::NodeSet
           result = nodes.map { |node|
-            value = node.xpath(extraction_details['value'] || '.')
-            if value.is_a?(Nokogiri::XML::NodeSet)
-              child = value.first
-              if child && child.cdata?
-                value = child.text
-              end
-            end
-            case value
+            case value = node.xpath(extraction_details['value'] || '.')
             when Float
               # Node#xpath() returns any numeric value as float;
               # convert it to integer as appropriate.


### PR DESCRIPTION
It was not really necessary since you could use an XPath expression `string(.)` to extract the content of a CDATA section, and it might get in the way if you are trying to get a CDATA section and its following siblings as a raw HTML/XML fragment.