### PR TITLE
Disable automatic URL normalization and absolutization on `url`

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -129,10 +129,11 @@ module LiquidInterpolatable
     # userinfo, host, port, registry, path, opaque, query, and
     # fragment.
     def to_uri(uri, base_uri = nil)
-      if base_uri
-        Utils.normalize_uri(base_uri) + Utils.normalize_uri(uri.to_s)
-      else
+      case base_uri
+      when nil, ''
         Utils.normalize_uri(uri.to_s)
+      else
+        Utils.normalize_uri(base_uri) + Utils.normalize_uri(uri.to_s)
       end
     rescue URI::Error
       nil

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -134,7 +134,7 @@ module Agents
 
       * `_response_`: A response object with the following keys:
 
-          * `status`: HTTP status as integer. (Almost always 200)  When parsing `data_from_event`, this is set to the value of the `status` key in the incoming Event.
+          * `status`: HTTP status as integer. (Almost always 200)  When parsing `data_from_event`, this is set to the value of the `status` key in the incoming Event, if it is a number or a string convertible to an integer.
 
           * `headers`: Response headers; for example, `{{ _response_.headers.Content-Type }}` expands to the value of the Content-Type header.  Keys are insensitive to cases and -/_.  When parsing `data_from_event`, this is constructed from the value of the `headers` key in the incoming Event.
 
@@ -694,7 +694,7 @@ module Agents
 
       # Integer value of HTTP status
       def status
-        @object.payload[:status]
+        Integer(@object.payload[:status]) rescue nil
       end
 
       # The URL

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -136,7 +136,7 @@ module Agents
 
           * `status`: HTTP status as integer. (Almost always 200)  When parsing `data_from_event`, this is set to the value of the `status` key in the incoming Event, if it is a number or a string convertible to an integer.
 
-          * `headers`: Response headers; for example, `{{ _response_.headers.Content-Type }}` expands to the value of the Content-Type header.  Keys are insensitive to cases and -/_.  When parsing `data_from_event`, this is constructed from the value of the `headers` key in the incoming Event.
+          * `headers`: Response headers; for example, `{{ _response_.headers.Content-Type }}` expands to the value of the Content-Type header.  Keys are insensitive to cases and -/_.  When parsing `data_from_event`, this is constructed from the value of the `headers` key in the incoming Event, if it is a hash.
 
           * `url`: The final URL of the fetched page, following redirects.  When parsing `data_from_event`, this is set to the value of the `url` key in the incoming Event.  Using this in the `template` option, you can resolve relative URLs extracted from a document like `{{ link | to_uri: _request_.url }}` and `{{ content | rebase_hrefs: _request_.url }}`.
 
@@ -684,12 +684,9 @@ module Agents
 
     class ResponseFromEventDrop < LiquidDroppable::Drop
       def headers
-        case headers = @object.payload[:headers]
-        when Hash
-          HeaderDrop.new(Faraday::Utils::Headers.from(headers))
-        else
-          HeaderDrop.new({})
-        end
+        headers = Faraday::Utils::Headers.from(@object.payload[:headers]) rescue {}
+
+        HeaderDrop.new(headers)
       end
 
       # Integer value of HTTP status

--- a/db/migrate/20161124065838_add_templates_to_resolve_url.rb
+++ b/db/migrate/20161124065838_add_templates_to_resolve_url.rb
@@ -1,0 +1,16 @@
+class AddTemplatesToResolveUrl < ActiveRecord::Migration[5.0]
+  def up
+    Agents::WebsiteAgent.find_each do |agent|
+      if agent.event_keys.try!(:include?, 'url')
+        agent.options['template'] = (agent.options['template'] || {}).tap { |template|
+          template['url'] ||= '{{ url | to_uri: _response_.url }}'
+        }
+        agent.save!(validate: false)
+      end
+    end
+  end
+
+  def down
+    # No need to revert
+  end
+end

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -119,6 +119,15 @@ describe LiquidInterpolatable::Filters do
       @agent.interpolation_context['s'] = 'foo/index.html'
       expect(@agent.interpolated['foo']).to eq('/dir/foo/index.html')
     end
+
+    it 'should normalize a URI value if an empty base URI is given' do
+      @agent.options['foo'] = '{{ u | to_uri: b }}'
+      @agent.interpolation_context['u'] = "\u{3042}"
+      @agent.interpolation_context['b'] = ""
+      expect(@agent.interpolated['foo']).to eq('%E3%81%82')
+      @agent.interpolation_context['b'] = nil
+      expect(@agent.interpolated['foo']).to eq('%E3%81%82')
+    end
   end
 
   describe 'uri_expand' do

--- a/spec/migrations/20161124065838_add_templates_to_resolve_url_spec.rb
+++ b/spec/migrations/20161124065838_add_templates_to_resolve_url_spec.rb
@@ -1,0 +1,39 @@
+load 'spec/rails_helper.rb'
+load File.join('db/migrate', File.basename(__FILE__, '_spec.rb') + '.rb')
+
+describe AddTemplatesToResolveUrl do
+  let :valid_options do
+    {
+      'name' => "XKCD",
+      'expected_update_period_in_days' => "2",
+      'type' => "html",
+      'url' => "http://xkcd.com",
+      'mode' => 'on_change',
+      'extract' => {
+        'url' => { 'css' => "#comic img", 'value' => "@src" },
+        'title' => { 'css' => "#comic img", 'value' => "@alt" },
+        'hovertext' => { 'css' => "#comic img", 'value' => "@title" }
+      }
+    }
+  end
+
+  let :agent do
+    Agents::WebsiteAgent.create!(
+      user: users(:bob),
+      name: "xkcd",
+      options: valid_options,
+      keep_events_for: 2.days
+    )
+  end
+
+  it 'should add a template for an existing WebsiteAgent with `url`' do
+    expect(agent.options).not_to include('template')
+    AddTemplatesToResolveUrl.new.up
+    agent.reload
+    expect(agent.options).to include(
+      'template' => {
+        'url' => '{{ url | to_uri: _response_.url }}'
+      }
+    )
+  end
+end

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -1198,7 +1198,7 @@ fire: hot
                 'value' => '{{ value }}',
                 'url' => '{{ url | to_uri: _response_.url }}',
                 'type' => '{{ _response_.headers.content_type }}',
-                'status' => '{{ _response_.status }}'
+                'status' => '{{ _response_.status | as_object }}'
               }
             )
           end
@@ -1207,7 +1207,7 @@ fire: hot
             expect {
               @checker.receive([@event])
             }.to change { Event.count }.by(1)
-            expect(@checker.events.last.payload).to eq({ 'value' => 'world', 'url' => 'http://example.com/world', 'type' => 'application/json', 'status' => '200' })
+            expect(@checker.events.last.payload).to eq({ 'value' => 'world', 'url' => 'http://example.com/world', 'type' => 'application/json', 'status' => 200 })
           end
 
           it "should support merge mode" do
@@ -1216,7 +1216,7 @@ fire: hot
             expect {
               @checker.receive([@event])
             }.to change { Event.count }.by(1)
-            expect(@checker.events.last.payload).to eq(@event.payload.merge('value' => 'world', 'url' => 'http://example.com/world', 'type' => 'application/json', 'status' => '200'))
+            expect(@checker.events.last.payload).to eq(@event.payload.merge('value' => 'world', 'url' => 'http://example.com/world', 'type' => 'application/json', 'status' => 200))
           end
 
           it "should output an error when nothing can be found at the path" do


### PR DESCRIPTION
This introduces a new option `resolve_url` turned off by default, as discussed in #1766.

For backward compatibility, existing WebsiteAgents with a key named `url` will be altered to have the option turned on via migration.