### PR TITLE
Cache Agent type select options in Agent#new

### DIFF
--- a/app/helpers/agent_helper.rb
+++ b/app/helpers/agent_helper.rb
@@ -82,6 +82,12 @@ module AgentHelper
     end
   end
 
+  def agent_type_select_options
+    Rails.cache.fetch('agent_type_select_options') do
+      [['Select an Agent Type', 'Agent', {title: ''}]] + Agent.types.map {|type| [agent_type_to_human(type.name), type, {title: h(Agent.build_for_type(type.name, User.new(id: 0), {}).html_description.lines.first.strip)}] }
+    end
+  end
+
   private
 
   def links_counter_cache(agents)

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -25,7 +25,7 @@
           <% if @agent.new_record? %>
             <div class="form-group type-select">
               <%= f.label :type %>
-              <%= f.select :type, options_for_select([['Select an Agent Type', 'Agent', {title: ''}]] + Agent.types.map {|type| [agent_type_to_human(type.name), type, {title: h(Agent.build_for_type(type.name,current_user,{}).html_description.lines.first.strip)}] }, @agent.type), {}, class: 'form-control', autofocus: true %>
+              <%= f.select :type, options_for_select(agent_type_select_options, @agent.type), {}, class: 'form-control', autofocus: true %>
             </div>
           <% end %>
         </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Huginn::Application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   if ENV['ASSET_HOST'].present?


### PR DESCRIPTION
Agent#new was by far the slowest action of all controllers. When using many Agent gems the response time goes up to a point where the user starts to wonder if something is going wrong. By caching the Agent description the response time goes down from about 1 second to 100ms in development.