### PR TITLE
Fix a double-decoding problem in RssAgent

### DIFF
--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -179,7 +179,7 @@ module Agents
       else
         # Encoding is already known, so do not let the parser detect
         # it from the XML declaration in the content.
-        body.sub!(/(<\?xml(?:\s+\w+\s*=\s*(['"]).*?\2)*)\s+encoding\s*=\s*(['"]).*?\3/, '\\1')
+        body.sub!(/(\A\u{FEFF}?\s*<\?xml(?:\s+\w+\s*=\s*(['"]).*?\2)*)\s+encoding\s*=\s*(['"]).*?\3/, '\\1')
       end
       body
     end

--- a/spec/data_fixtures/iso-8859-1.rss
+++ b/spec/data_fixtures/iso-8859-1.rss
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+    <channel>
+        <title>Zeuhl</title>
+        <link>http://example.net/</link>
+        <item>
+            <title>Mëkanïk Zaïn</title>
+            <link>http://example.net/post/1</link>
+            <guid>http://example.net/post/1</guid>
+            <pubDate>Mon, 21 Nov 2016 17:00:10 +0100</pubDate>
+        </item>
+    </channel>
+</rss>

--- a/spec/models/agents/rss_agent_spec.rb
+++ b/spec/models/agents/rss_agent_spec.rb
@@ -12,6 +12,7 @@ describe Agents::RssAgent do
     stub_request(:any, /SlickdealsnetFP/).to_return(:body => File.read(Rails.root.join("spec/data_fixtures/slickdeals.atom")), :status => 200)
     stub_request(:any, /onethingwell.org/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/onethingwell.rss")), status: 200)
     stub_request(:any, /bad.onethingwell.org/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/onethingwell.rss")).gsub(/(?<=<link>)[^<]*/, ''), status: 200)
+    stub_request(:any, /iso-8859-1/).to_return(body: File.binread(Rails.root.join("spec/data_fixtures/iso-8859-1.rss")), headers: { 'Content-Type' => 'application/rss+xml; charset=ISO-8859-1' }, status: 200)
   end
 
   let(:agent) do
@@ -281,6 +282,18 @@ describe Agents::RssAgent do
         agent.check
         event = agent.events.first
         expect(event.payload['links']).to eq([])
+      end
+    end
+
+    context 'with the encoding declared in both headers and the content' do
+      before do
+        @valid_options['url'] = 'http://example.org/iso-8859-1.rss'
+      end
+
+      it "decodes the content properly" do
+        agent.check
+        event = agent.events.first
+        expect(event.payload['title']).to eq('Mëkanïk Zaïn')
       end
     end
   end


### PR DESCRIPTION
The SAX parser Feedjira uses (Nokogiri::XML::SAX) tries to detect the encoding of a document from the content even if it is already known and given.  This results in a content being decoded twice by WebRequestConcern and the SAX parser if its encoding is declared in both the Content-Type header and the XML declaration.

This commit makes RssAgent remove the `encoding` attribute from the XML declaration of a document if the encoding is already known by the Content-Type header.

Fixes #1797.