### PR TITLE
Make WebsiteAgent merge `template` with the results of `extract`

### DIFF
--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -37,6 +37,8 @@ module Agents
 
       Note that for all of the formats, whatever you extract MUST have the same number of matches for each extractor except when it has `repeat` set to true.  E.g., if you're extracting rows, all extractors must match all rows.  For generating CSS selectors, something like [SelectorGadget](http://selectorgadget.com) may be helpful.
 
+      For extractors with `hidden` set to true, they will be excluded from the payloads of events created by the Agent, but can be used and interpolated in the `template` option explained below.
+
       For extractors with `repeat` set to true, their first matches will be included in all extracts.  This is useful such as when you want to include the title of a page in all events created from the page.
 
       # Scraping HTML and XML
@@ -116,11 +118,9 @@ module Agents
 
       Set `http_success_codes` to an array of status codes (e.g., `[404, 422]`) to treat HTTP response codes beyond 200 as successes.
 
-      If a `template` option is given, it is used as a Liquid template for each event created by this Agent, instead of directly emitting the results of extraction as events.  In the template, keys of extracted data can be interpolated, and some additional variables are also available as explained in the next section.  For example:
+      If a `template` option is given, its value must be a hash, whose key-value pairs are interpolated after extraction for each iteration and merged with the payload.  In the template, keys of extracted data can be interpolated, and some additional variables are also available as explained in the next section.  For example:
 
           "template": {
-            "url": "{{ url }}",
-            "title": "{{ title }}",
             "description": "{{ body_text }}",
             "last_modified": "{{ _response_.headers.Last-Modified | date: '%FT%T' }}"
           }
@@ -159,7 +159,11 @@ module Agents
     end
 
     def event_keys
-      (options['template'].presence || options['extract']).try(:keys)
+      extract = options['extract'] or return nil
+
+      extract.each_with_object([]) { |(key, value), keys|
+        keys << key unless boolify(value['hidden'])
+      } | (options['template'].presence.try!(:keys) || [])
     end
 
     def working?
@@ -382,33 +386,19 @@ module Agents
             extract_xml(doc)
         end
 
-      num_tuples = output.each_value.inject(nil) { |num, value|
-        case size = value.size
-        when Float::INFINITY
-          num
-        when Integer
-          if num && num != size
-            raise "Got an uneven number of matches for #{interpolated['name']}: #{interpolated['extract'].inspect}"
-          end
-          size
-        end
-      } or raise "At least one non-repeat key is required"
+      num_tuples = output.size or
+        raise "At least one non-repeat key is required"
 
       old_events = previous_payloads num_tuples
 
       template = options['template'].presence
 
-      num_tuples.times.zip(*output.values) do |index, *values|
-        extracted = output.each_key.lazy.zip(values).to_h
+      output.each do |extracted|
+        result = extracted.except(*output.hidden_keys)
 
-        result =
-          if template
-            interpolate_with(extracted) do
-              interpolate_options(template)
-            end
-          else
-            extracted
-          end
+        if template
+          result.update(interpolate_options(template, extracted))
+        end
 
         # url may be URI, string or nil
         if (payload_url = result['url'].presence) && (url = url.presence)
@@ -528,7 +518,7 @@ module Agents
     end
 
     def extract_each(&block)
-      interpolated['extract'].each_with_object({}) { |(name, extraction_details), output|
+      interpolated['extract'].each_with_object(Output.new) { |(name, extraction_details), output|
         if boolify(extraction_details['repeat'])
           values = Repeater.new { |repeater|
             block.call(extraction_details, repeater)
@@ -538,7 +528,12 @@ module Agents
           block.call(extraction_details, values)
         end
         log "Values extracted: #{values}"
-        output[name] = values
+        begin
+          output[name] = values
+          output.hidden_keys << name if boolify(extraction_details['hidden'])
+        rescue ArgumentError
+          raise "Got an uneven number of matches for #{interpolated['name']}: #{interpolated['extract'].inspect}"
+        end
       }
     end
 
@@ -615,6 +610,35 @@ module Agents
       Integer(value) >= 0
     rescue
       false
+    end
+
+    class Output
+      def initialize
+        @hash = {}
+        @size = nil
+        @hidden_keys = []
+      end
+
+      attr_reader :size
+      attr_reader :hidden_keys
+
+      def []=(key, value)
+        case size = value.size
+        when Integer
+          if @size && @size != size
+            raise ArgumentError, 'got an uneven size'
+          end
+          @size = size
+        end
+
+        @hash[key] = value
+      end
+
+      def each
+        @size.times.zip(*@hash.values) do |index, *values|
+          yield @hash.each_key.lazy.zip(values).to_h
+        end
+      end
     end
 
     class Repeater < Enumerator

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -530,9 +530,10 @@ module Agents
         log "Values extracted: #{values}"
         begin
           output[name] = values
-          output.hidden_keys << name if boolify(extraction_details['hidden'])
-        rescue ArgumentError
+        rescue UnevenSizeError
           raise "Got an uneven number of matches for #{interpolated['name']}: #{interpolated['extract'].inspect}"
+        else
+          output.hidden_keys << name if boolify(extraction_details['hidden'])
         end
       }
     end
@@ -612,6 +613,9 @@ module Agents
       false
     end
 
+    class UnevenSizeError < ArgumentError
+    end
+
     class Output
       def initialize
         @hash = {}
@@ -626,7 +630,7 @@ module Agents
         case size = value.size
         when Integer
           if @size && @size != size
-            raise ArgumentError, 'got an uneven size'
+            raise UnevenSizeError, 'got an uneven size'
           end
           @size = size
         end

--- a/db/migrate/20161124061256_convert_website_agent_template_for_merge.rb
+++ b/db/migrate/20161124061256_convert_website_agent_template_for_merge.rb
@@ -10,7 +10,8 @@ class ConvertWebsiteAgentTemplateForMerge < ActiveRecord::Migration[5.0]
       end
 
       template.delete_if { |key, value|
-        value.match(/\A\{\{\s*#{Regexp.quote(key)}\s*\}\}\z/)
+        extract.key?(key) &&
+          value.match(/\A\{\{\s*#{Regexp.quote(key)}\s*\}\}\z/)
       }
 
       agent.save!(validate: false)

--- a/db/migrate/20161124061256_convert_website_agent_template_for_merge.rb
+++ b/db/migrate/20161124061256_convert_website_agent_template_for_merge.rb
@@ -1,0 +1,35 @@
+class ConvertWebsiteAgentTemplateForMerge < ActiveRecord::Migration[5.0]
+  def up
+    Agents::WebsiteAgent.find_each do |agent|
+      extract = agent.options['extract'].presence
+      template = agent.options['template'].presence
+      next unless extract.is_a?(Hash) && template.is_a?(Hash)
+
+      (extract.keys - template.keys).each do |key|
+        extract[key]['hidden'] = true
+      end
+
+      template.delete_if { |key, value|
+        value.match(/\A\{\{\s*#{Regexp.quote(key)}\s*\}\}\z/)
+      }
+
+      agent.save!(validate: false)
+    end
+  end
+
+  def down
+    Agents::WebsiteAgent.find_each do |agent|
+      extract = agent.options['extract'].presence
+      template = agent.options['template'].presence
+      next unless extract.is_a?(Hash) && template.is_a?(Hash)
+
+      (extract.keys - template.keys).each do |key|
+        unless extract[key].delete('hidden').in?([true, 'true'])
+          template[key] = "{{ #{key} }}"
+        end
+      end
+
+      agent.save!(validate: false)
+    end
+  end
+end

--- a/spec/migrations/20161124061256_convert_website_agent_template_for_merge_spec.rb
+++ b/spec/migrations/20161124061256_convert_website_agent_template_for_merge_spec.rb
@@ -26,13 +26,15 @@ describe ConvertWebsiteAgentTemplateForMerge do
     {
       'url' => '{{url}}',
       'title' => '{{ title }}',
-      'description' => '{{ hovertext }}'
+      'description' => '{{ hovertext }}',
+      'comment' => '{{ comment }}'
     }
   end
 
   let :new_template do
     {
-      'description' => '{{ hovertext }}'
+      'description' => '{{ hovertext }}',
+      'comment' => '{{ comment }}'
     }
   end
 
@@ -45,7 +47,7 @@ describe ConvertWebsiteAgentTemplateForMerge do
       'name' => "XKCD",
       'expected_update_period_in_days' => "2",
       'type' => "html",
-      'url' => "http://xkcd.com",
+      'url' => "{{ url | default: 'http://xkcd.com/' }}",
       'mode' => 'on_change',
       'extract' => old_extract,
       'template' => old_template

--- a/spec/migrations/20161124061256_convert_website_agent_template_for_merge_spec.rb
+++ b/spec/migrations/20161124061256_convert_website_agent_template_for_merge_spec.rb
@@ -1,0 +1,90 @@
+load 'spec/rails_helper.rb'
+load File.join('db/migrate', File.basename(__FILE__, '_spec.rb') + '.rb')
+
+describe ConvertWebsiteAgentTemplateForMerge do
+  let :old_extract do
+    {
+      'url' => { 'css' => "#comic img", 'value' => "@src" },
+      'title' => { 'css' => "#comic img", 'value' => "@alt" },
+      'hovertext' => { 'css' => "#comic img", 'value' => "@title" }
+    }
+  end
+
+  let :new_extract do
+    {
+      'url' => { 'css' => "#comic img", 'value' => "@src" },
+      'title' => { 'css' => "#comic img", 'value' => "@alt" },
+      'hovertext' => { 'css' => "#comic img", 'value' => "@title", 'hidden' => true }
+    }
+  end
+
+  let :reverted_extract do
+    old_extract
+  end
+
+  let :old_template do
+    {
+      'url' => '{{url}}',
+      'title' => '{{ title }}',
+      'description' => '{{ hovertext }}'
+    }
+  end
+
+  let :new_template do
+    {
+      'description' => '{{ hovertext }}'
+    }
+  end
+
+  let :reverted_template do
+    old_template.merge('url' => '{{ url }}')
+  end
+
+  let :valid_options do
+    {
+      'name' => "XKCD",
+      'expected_update_period_in_days' => "2",
+      'type' => "html",
+      'url' => "http://xkcd.com",
+      'mode' => 'on_change',
+      'extract' => old_extract,
+      'template' => old_template
+    }
+  end
+
+  let :agent do
+    Agents::WebsiteAgent.create!(
+      user: users(:bob),
+      name: "xkcd",
+      options: valid_options,
+      keep_events_for: 2.days
+    )
+  end
+
+  describe 'up' do
+    it 'should update extract and template options for an existing WebsiteAgent' do
+      expect(agent.options).to include('extract' => old_extract,
+                                       'template' => old_template)
+      ConvertWebsiteAgentTemplateForMerge.new.up
+      agent.reload
+      expect(agent.options).to include('extract' => new_extract,
+                                       'template' => new_template)
+    end
+  end
+
+  describe 'down' do
+    let :valid_options do
+      super().merge('extract' => new_extract,
+                    'template' => new_template)
+    end
+
+    it 'should revert extract and template options for an updated WebsiteAgent' do
+      expect(agent.options).to include('extract' => new_extract,
+                                       'template' => new_template)
+      ConvertWebsiteAgentTemplateForMerge.new.down
+      agent.reload
+      expect(agent.options).to include('extract' => reverted_extract,
+                                       'template' => reverted_template)
+    end
+  end
+end

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -651,9 +651,22 @@ describe Agents::WebsiteAgent do
         @checker.options = @valid_options
         @checker.check
         event = Event.last
-        expect(event.payload['url']).to eq("http://imgs.xkcd.com/comics/evolving.png")
-        expect(event.payload['title']).to eq("Evolving")
-        expect(event.payload['hovertext']).to match(/^Biologists play reverse/)
+        expect(event.payload).to match(
+          'url' => 'http://imgs.xkcd.com/comics/evolving.png',
+          'title' => 'Evolving',
+          'hovertext' => /^Biologists play reverse/
+        )
+      end
+
+      it "should exclude hidden keys" do
+        @valid_options['extract']['hovertext']['hidden'] = true
+        @checker.options = @valid_options
+        @checker.check
+        event = Event.last
+        expect(event.payload).to match(
+          'url' => 'http://imgs.xkcd.com/comics/evolving.png',
+          'title' => 'Evolving'
+        )
       end
 
       it "should turn relative urls to absolute" do
@@ -749,9 +762,9 @@ describe Agents::WebsiteAgent do
         expect(event.payload['original_url']).to eq('http://xkcd.com/index')
       end
 
-      it "should be formatted by template after extraction" do
+      it "should format and merge values in template after extraction" do
+        @valid_options['extract']['hovertext']['hidden'] = true
         @valid_options['template'] = {
-          'url' => '{{url}}',
           'title' => '{{title | upcase}}',
           'summary' => '{{title}}: {{hovertext | truncate: 20}}',
         }


### PR DESCRIPTION
A new extraction option `hidden` is added so that keys with it gets excluded from the final payloads while they can be used in `template`.