### PR TITLE
Make migrations compatible with SQLite

### DIFF
--- a/db/migrate/20130107050049_add_invitation_code_to_users.rb
+++ b/db/migrate/20130107050049_add_invitation_code_to_users.rb
@@ -1,5 +1,6 @@
 class AddInvitationCodeToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :invitation_code, :string, :null => false
+    add_column :users, :invitation_code, :string
+    change_column :users, :invitation_code, :string, :null => false
   end
 end

--- a/db/migrate/20140531232016_add_fields_to_scenarios.rb
+++ b/db/migrate/20140531232016_add_fields_to_scenarios.rb
@@ -2,7 +2,8 @@ class AddFieldsToScenarios < ActiveRecord::Migration
   def change
     add_column :scenarios, :description, :text
     add_column :scenarios, :public, :boolean, :default => false, :null => false
-    add_column :scenarios, :guid, :string, :null => false
+    add_column :scenarios, :guid, :string
+    change_column :scenarios, :guid, :string, :null => false
     add_column :scenarios, :source_url, :string
   end
 end

--- a/db/migrate/20160301113717_add_confirmable_attributes_to_users.rb
+++ b/db/migrate/20160301113717_add_confirmable_attributes_to_users.rb
@@ -11,7 +11,7 @@ class AddConfirmableAttributesToUsers < ActiveRecord::Migration
     add_index :users, :confirmation_token,   unique: true
 
     if ENV['REQUIRE_CONFIRMED_EMAIL'] != 'true' && ActiveRecord::Base.connection.column_exists?(:users, :confirmed_at)
-      User.update_all('confirmed_at = NOW()')
+      User.update_all(confirmed_at: Time.zone.now)
     end
   end
 end


### PR DESCRIPTION
Hi,

I wanted to quickly setup a demo instance of `huginn` to have a look and see if it could match my use case. I did not have a running MySQL or PostgreSQL instance to use for this purpose, and wishes `huginn` worked out of the box with `sqlite3` database, cutting any dependency on specific databases.

Not sure if this may be something of interest for others, that is interesting to get merged, but this PR makes all the migrations work with SQLite, and huginn should be working with SQLite as a db backend afterwards, at least as far as I could see during my tests.