### PR TITLE
Ensure Twitter REST API calls always get extended tweets

### DIFF
--- a/app/models/agents/twitter_favorites.rb
+++ b/app/models/agents/twitter_favorites.rb
@@ -76,7 +76,7 @@ module Agents
     end
 
     def check
-      opts = {:count => interpolated['number']}
+      opts = {:count => interpolated['number'], tweet_mode: 'extended'}
       tweets = twitter.favorites(interpolated['username'], opts)
       memory[:last_seen] ||= []
 

--- a/app/models/agents/twitter_search_agent.rb
+++ b/app/models/agents/twitter_search_agent.rb
@@ -84,7 +84,7 @@ module Agents
 
     def check
       since_id = memory['since_id'] || nil
-      opts = {include_entities: true}
+      opts = {include_entities: true, tweet_mode: 'extended'}
       opts.merge! result_type: interpolated[:result_type] if interpolated[:result_type].present?
       opts.merge! since_id: since_id unless since_id.nil?
 

--- a/app/models/agents/twitter_user_agent.rb
+++ b/app/models/agents/twitter_user_agent.rb
@@ -98,7 +98,7 @@ module Agents
 
     def check
       since_id = memory['since_id'] || nil
-      opts = {:count => 200, :include_rts => include_retweets?, :exclude_replies => exclude_replies?, :include_entities => true, :contributor_details => true}
+      opts = {:count => 200, :include_rts => include_retweets?, :exclude_replies => exclude_replies?, :include_entities => true, :contributor_details => true, tweet_mode: 'extended'}
       opts.merge! :since_id => since_id unless since_id.nil?
 
       if choose_home_time_line?

--- a/spec/models/agents/twitter_favorites_spec.rb
+++ b/spec/models/agents/twitter_favorites_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Agents::TwitterFavorites do
   before do
-    stub_request(:any, /tectonic/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/user_fav_tweets.json")), status: 200)
+    stub_request(:any, /tectonic.+?tweet_mode=extended/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/user_fav_tweets.json")), status: 200)
   end
 
   before do

--- a/spec/models/agents/twitter_search_agent_spec.rb
+++ b/spec/models/agents/twitter_search_agent_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 describe Agents::TwitterSearchAgent do
   before do
     # intercept the twitter API request
-    stub_request(:any, /freebandnames/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/search_tweets.json")), status: 200)
-
+    stub_request(:any, /freebandnames.+?tweet_mode=extended/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/search_tweets.json")), status: 200)
     @opts = {
       search: "freebandnames",
       expected_update_period_in_days: "2",

--- a/spec/models/agents/twitter_user_agent_spec.rb
+++ b/spec/models/agents/twitter_user_agent_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Agents::TwitterUserAgent do
   before do
     # intercept the twitter API request for @tectonic's user profile
-    stub_request(:any, "https://api.twitter.com/1.1/statuses/user_timeline.json?contributor_details=true&count=200&exclude_replies=false&include_entities=true&include_rts=true&screen_name=tectonic").to_return(:body => File.read(Rails.root.join("spec/data_fixtures/user_tweets.json")), :status => 200)
+    stub_request(:any, "https://api.twitter.com/1.1/statuses/user_timeline.json?contributor_details=true&count=200&exclude_replies=false&include_entities=true&include_rts=true&screen_name=tectonic&tweet_mode=extended").to_return(:body => File.read(Rails.root.join("spec/data_fixtures/user_tweets.json")), :status => 200)
 
     @opts = {
       :username => "tectonic",
@@ -44,7 +44,7 @@ describe Agents::TwitterUserAgent do
 
   describe "#check that if choose time line is false then username is required" do
     before do
-      stub_request(:any, "https://api.twitter.com/1.1/statuses/home_timeline.json?contributor_details=true&count=200&exclude_replies=false&include_entities=true&include_rts=true").to_return(:body => File.read(Rails.root.join("spec/data_fixtures/user_tweets.json")), :status => 200)
+      stub_request(:any, "https://api.twitter.com/1.1/statuses/home_timeline.json?contributor_details=true&count=200&exclude_replies=false&include_entities=true&include_rts=true&tweet_mode=extended").to_return(:body => File.read(Rails.root.join("spec/data_fixtures/user_tweets.json")), :status => 200)
     end
 
     it 'requires username unless choose_home_time_line is true' do


### PR DESCRIPTION
Tweets that include embedds are truncated by default (https://dev.twitter.com/overview/api/upcoming-changes-to-tweets) by passing tweet_mode=extened to the REST API calls we ensure to get the full response including embedded images and videos