### PR TITLE
Expose Agent#id to Liquid (and to JavaScriptAgent)

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -445,19 +445,20 @@ class AgentDrop
     @object.short_type
   end
 
-  METHODS = [
-    :name,
-    :type,
-    :options,
-    :memory,
-    :sources,
-    :receivers,
-    :schedule,
-    :controllers,
-    :control_targets,
-    :disabled,
-    :keep_events_for,
-    :propagate_immediately,
+  METHODS = %i[
+    id
+    name
+    type
+    options
+    memory
+    sources
+    receivers
+    schedule
+    controllers
+    control_targets
+    disabled
+    keep_events_for
+    propagate_immediately
   ]
 
   METHODS.each { |attr|

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -1013,11 +1013,11 @@ describe AgentDrop do
     expect(@efa.to_liquid.class).to be(AgentDrop)
   end
 
-  it 'should have .type and .name' do
-    t = '{{agent.type}}: {{agent.name}}'
-    expect(interpolate(t, @wsa1)).to eq('WebsiteAgent: XKCD')
-    expect(interpolate(t, @wsa2)).to eq('WebsiteAgent: Dilbert')
-    expect(interpolate(t, @efa)).to eq('EventFormattingAgent: Formatter')
+  it 'should have .id, .type and .name' do
+    t = '[{{agent.id}}]{{agent.type}}: {{agent.name}}'
+    expect(interpolate(t, @wsa1)).to eq("[#{@wsa1.id}]WebsiteAgent: XKCD")
+    expect(interpolate(t, @wsa2)).to eq("[#{@wsa2.id}]WebsiteAgent: Dilbert")
+    expect(interpolate(t, @efa)).to eq("[#{@efa.id}]EventFormattingAgent: Formatter")
   end
 
   it 'should have .options' do


### PR DESCRIPTION
It would be handy if, for example, a JavaScriptAgent could identify the source of an incoming event by ID and store per-source information in the memory.