### PR TITLE
Allow Redirect Requests

### DIFF
--- a/app/controllers/web_requests_controller.rb
+++ b/app/controllers/web_requests_controller.rb
@@ -26,12 +26,16 @@ class WebRequestsController < ApplicationController
       if agent
         content, status, content_type = agent.trigger_web_request(request)
 
-        if content.is_a?(String)
-          render plain: content, :status => status || 200, :content_type => content_type || 'text/plain'
+        status = status || 200
+
+        if status.in?([301, 302])
+          redirect_to content, status: status
+        elsif content.is_a?(String)
+          render plain: content, :status => status, :content_type => content_type || 'text/plain'
         elsif content.is_a?(Hash)
-          render :json => content, :status => status || 200
+          render :json => content, :status => status
         else
-          head(status || 200)
+          head(status)
         end
       else
         render plain: "agent not found", :status => 404

--- a/app/controllers/web_requests_controller.rb
+++ b/app/controllers/web_requests_controller.rb
@@ -28,7 +28,7 @@ class WebRequestsController < ApplicationController
 
         status = status || 200
 
-        if status.in?([301, 302])
+        if status.to_s.in?(["301", "302"])
           redirect_to content, status: status
         elsif content.is_a?(String)
           render plain: content, :status => status, :content_type => content_type || 'text/plain'

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -26,7 +26,7 @@ module Agents
           For example, "post,get" will enable POST and GET requests. Defaults
           to "post".
         * `response` - The response message to the request. Defaults to 'Event Created'.
-        * `code` - The response code to the request. Defaults to '201'.
+        * `code` - The response code to the request. Defaults to '201'. If the code is '301' or '302' the request will automatically be redirected to the url defined in "response".
         * `recaptcha_secret` - Setting this to a reCAPTCHA "secret" key makes your agent verify incoming requests with reCAPTCHA.  Don't forget to embed a reCAPTCHA snippet including your "site" key in the originating form(s).
         * `recaptcha_send_remote_addr` - Set this to true if your server is properly configured to set REMOTE_ADDR to the IP address of each visitor (instead of that of a proxy server).
       MD
@@ -54,7 +54,7 @@ module Agents
       # check the verbs
       verbs = (interpolated['verbs'] || 'post').split(/,/).map { |x| x.strip.downcase }.select { |x| x.present? }
       return ["Please use #{verbs.join('/').upcase} requests only", 401] unless verbs.include?(method)
-      
+
       # check the code
       code = (interpolated['code'].presence || 201).to_i
 
@@ -102,6 +102,10 @@ module Agents
 
       if options['code'].present? && options['code'].to_s !~ /\A\s*(\d+|\{.*)\s*\z/
         errors.add(:base, "Must specify a code for request responses")
+      end
+
+      if options['code'].in?(['301', '302']) && !options['response'].present?
+        errors.add(:base, "Must specify a url for request redirect")
       end
     end
 

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -104,7 +104,7 @@ module Agents
         errors.add(:base, "Must specify a code for request responses")
       end
 
-      if options['code'].in?(['301', '302']) && !options['response'].present?
+      if options['code'].to_s.in?(['301', '302']) && !options['response'].present?
         errors.add(:base, "Must specify a url for request redirect")
       end
     end

--- a/spec/controllers/web_requests_controller_spec.rb
+++ b/spec/controllers/web_requests_controller_spec.rb
@@ -10,7 +10,7 @@ describe WebRequestsController do
         memory[:web_request_values] = params
         memory[:web_request_format] = format
         memory[:web_request_method] = method
-        ["success", 200, memory['content_type']]
+        ["success", (options[:status] || 200).to_i, memory['content_type']]
       else
         ["failure", 404]
       end
@@ -83,6 +83,13 @@ describe WebRequestsController do
     @agent.save!
     get :handle_request, params: {:user_id => users(:bob).to_param, :agent_id => @agent.id, :secret => "my_secret", :key => "value", :another_key => "5"}
     expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+  end
+
+  it 'should redirect correctly' do
+    @agent.options['status'] = 302
+    @agent.save
+    post :handle_request, params: {:user_id => users(:bob).to_param, :agent_id => @agent.id, :secret => "my_secret"}, format: :json
+    expect(response).to redirect_to('success')
   end
 
   it "should fail on incorrect users" do


### PR DESCRIPTION
Use Case: The user fills out a form that is posted to the webhook and then he is redirected to the success page.

PS: I'm not a Ruby programmer, you know, right? Please have patience with my code 😉 