### PR TITLE
let default table inherit the boostrap #table css style

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -27,6 +27,10 @@ body { padding-top: 60px; }
   margin-bottom: 100px;
 }
 
+table {
+  @extend .table;
+}
+
 .well.description {
   h1 { font-size: 30px; }
   h2 { font-size: 26px; }

--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -27,11 +27,10 @@ body { padding-top: 60px; }
   margin-bottom: 100px;
 }
 
-table {
-  @extend .table;
-}
-
 .well.description {
+  table {
+    @extend .table;
+  }
   h1 { font-size: 30px; }
   h2 { font-size: 26px; }
   h3 { font-size: 22px; }


### PR DESCRIPTION
Fixes #1795.

let the markdown can show the table like the picture.

|-----------------+------------+-----------------+----------------|
| Default aligned |Left aligned| Center aligned  | Right aligned  |
|-----------------|:-----------|:---------------:|---------------:|
| First body part |Second cell | Third cell      | fourth cell    |
| Second line     |foo         | **strong**      | baz            |
| Third line      |quux        | baz             | bar            |
|-----------------+------------+-----------------+----------------|
| Second body     |            |                 |                |
| 2 line          |            |                 |                |
|=================+============+=================+================|
| Footer row      |            |                 |                |
|-----------------+------------+-----------------+----------------|

<img width="571" alt="2017-01-24 3 04 22" src="https://cloud.githubusercontent.com/assets/6713879/22237395/733df0d4-e246-11e6-868b-1503139a4160.png">

