### PR TITLE
Rename Delayed::Job failed scope to prevent warning

### DIFF
--- a/app/controllers/worker_status_controller.rb
+++ b/app/controllers/worker_status_controller.rb
@@ -22,7 +22,7 @@ class WorkerStatusController < ApplicationController
     render json: {
       pending: Delayed::Job.pending.where("run_at <= ?", start).count,
       awaiting_retry: Delayed::Job.awaiting_retry.count,
-      recent_failures: Delayed::Job.failed.where('failed_at > ?', 5.days.ago).count,
+      recent_failures: Delayed::Job.failed_jobs.where('failed_at > ?', 5.days.ago).count,
       event_count: count,
       max_id: max_id || 0,
       events_url: events_url,

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -14,7 +14,7 @@ ActiveSupport.on_load(:delayed_job_active_record) do
   class Delayed::Job
     scope :pending, -> { where("locked_at IS NULL AND attempts = 0") }
     scope :awaiting_retry, -> { where("failed_at IS NULL AND attempts > 0 AND locked_at IS NULL") }
-    scope :failed, -> { where("failed_at IS NOT NULL") }
+    scope :failed_jobs, -> { where("failed_at IS NOT NULL") }
   end
 
   database_deadlocks_when_using_optimized_strategy = lambda do


### PR DESCRIPTION
Fixes #1806