### PR TITLE
Fix devise confirmation form, unify unlock form

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,20 +1,25 @@
 <% content_for :title, "Resend confirmation" -%>
 
 <div class='row'>
-  <div class='col-md-8 col-md-offset-2'>
+  <div class='col-md-6 col-md-offset-3'>
     <div class='well'>
-
       <h2>Resend confirmation instructions</h2>
 
       <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'form-horizontal' }) do |f| %>
         <%= devise_error_messages! %>
 
         <div class="form-group">
-          <%= f.label :email %>
-          <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+          <%= f.label :login, class: 'col-md-2 col-md-offset-2 control-label' %>
+          <div class="col-md-6">
+            <%= f.text_field :login, autofocus: true, class: 'form-control' %>
+          </div>
         </div>
 
-        <%= f.submit "Resend confirmation instructions", class: "btn btn-primary" %>
+        <div class="form-group">
+          <div class="col-md-offset-4 col-md-10">
+            <%= f.submit "Resend confirmation instructions", class: "btn btn-primary" %>
+          </div>
+        </div>
       <% end %>
 
       <%= render "devise/shared/links" %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -9,9 +9,9 @@
         <%= devise_error_messages! %>
 
         <div class="form-group">
-         <%= f.label :email, class: 'col-md-2 col-md-offset-2 control-label' %>
+         <%= f.label :login, class: 'col-md-2 col-md-offset-2 control-label' %>
           <div class="col-md-6">
-            <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+            <%= f.text_field :login, autofocus: true, class: 'form-control' %>
           </div>
         </div>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -161,7 +161,7 @@ Devise.setup do |config|
   config.lock_strategy = Utils.if_present(ENV['LOCK_STRATEGY'], :to_sym) || :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
-  config.unlock_keys = [ :email ]
+  config.unlock_keys = [ :login ]
 
   # Defines which strategy will be used to unlock an account.
   # :email = Sends an unlock link to the user email


### PR DESCRIPTION
Use `login` as the key for all devise request/resend forms.

Fixes #1895