### PR TITLE
Check for agent class file to determine if it's valid

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -418,7 +418,7 @@ class Agent < ActiveRecord::Base
       return if schedule == 'never'
       types = where(:schedule => schedule).group(:type).pluck(:type)
       types.each do |type|
-        next unless const_defined?(type)
+        next unless valid_type?(type)
         type.constantize.bulk_check(schedule)
       end
     end


### PR DESCRIPTION
Fixes #1906.

The previous approach of checking if the class is defined caused problems when the agent class had not yet been loaded by the process. Using `valid_type?` instead seems to be the approach that is used elsewhere in the codebase, and it does not suffer from this problem.

I wasn’t able to write a test to catch regressions on this, because I’m not able to test that an agent is *not* used without causing the test to load its class, which causes the agent to be used (bypassing the bug).