### PR TITLE
Allow path to accept stored credentials in shell_command_agent.rb

### DIFF
--- a/app/models/agents/shell_command_agent.rb
+++ b/app/models/agents/shell_command_agent.rb
@@ -68,7 +68,7 @@ module Agents
         errors.add(:base, "command must be a shell command line string or an array of command line arguments.")
       end
 
-      unless File.directory?(options['path'])
+      unless File.directory?(interpolated['path'])
         errors.add(:base, "#{options['path']} is not a real directory.")
       end
     end


### PR DESCRIPTION
Change to make path accept stored credentials.

Example:

"path": "/home/{% credential luser %}/website/{% credential grepo %}.github.io/_posts/",