### PR TITLE
Make feature specs more robust

### DIFF
--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -15,6 +15,7 @@ Capybara.default_max_wait_time = CAPYBARA_TIMEOUT
 RSpec.configure do |config|
   config.include Warden::Test::Helpers
   config.include AlertConfirmer, type: :feature
+  config.include FeatureHelpers, type: :feature
 
   config.before(:suite) do
     Warden.test_mode!

--- a/spec/features/create_an_agent_spec.rb
+++ b/spec/features/create_an_agent_spec.rb
@@ -10,7 +10,7 @@ describe "Creating a new agent", js: true do
     page.find("a", text: "Agents").trigger(:mouseover)
     click_on("New Agent")
 
-    select2("Trigger Agent", from: "Type")
+    select_agent_type("Trigger Agent")
     fill_in(:agent_name, with: "Test Trigger Agent")
     click_on "Save"
 
@@ -22,7 +22,7 @@ describe "Creating a new agent", js: true do
     page.find("a", text: "Agents").trigger(:mouseover)
     click_on("New Agent")
 
-    select2("Trigger Agent", from: "Type")
+    select_agent_type("Trigger Agent")
     fill_in(:agent_name, with: "Test Trigger Agent")
     click_on("Toggle View")
 
@@ -37,20 +37,21 @@ describe "Creating a new agent", js: true do
     before(:each) do
       visit new_agent_path
     end
+
     it "shows all options for agents that can be scheduled, create and receive events" do
-      select2("Website Agent scrapes", from: "Type")
+      select_agent_type("Website Agent scrapes")
       expect(page).not_to have_content('This type of Agent cannot create events.')
     end
 
     it "does not show the target select2 field when the agent can not create events" do
-      select2("Growl Agent", from: "Type")
+      select_agent_type("Growl Agent")
       expect(page).to have_content('This type of Agent cannot create events.')
     end
   end
 
   it "allows to click on on the agent name in select2 tags" do
     visit new_agent_path
-    select2("Website Agent scrapes", from: "Type")
+    select_agent_type("Website Agent scrapes")
     select2("SF Weather", from: 'Sources')
     click_on "SF Weather"
     expect(page).to have_content "Editing your WeatherAgent"
@@ -62,10 +63,9 @@ describe "Creating a new agent", js: true do
     end
 
     it "does not send previously configured sources when the current agent does not support them" do
-      select2("Website Agent scrapes", from: "Type")
-      sleep 0.5
+      select_agent_type("Website Agent scrapes")
       select2("SF Weather", from: 'Sources')
-      select2("Webhook Agent", from: "Type")
+      select_agent_type("Webhook Agent")
       fill_in(:agent_name, with: "No sources")
       click_on "Save"
       expect(page).to have_content("No sources")
@@ -74,10 +74,9 @@ describe "Creating a new agent", js: true do
     end
 
     it "does not send previously configured control targets when the current agent does not support them" do
-      select2("Commander Agent", from: "Type")
-      sleep 0.5
+      select_agent_type("Commander Agent")
       select2("SF Weather", from: 'Control targets')
-      select2("Webhook Agent", from: "Type")
+      select_agent_type("Webhook Agent")
       fill_in(:agent_name, with: "No control targets")
       click_on "Save"
       expect(page).to have_content("No control targets")
@@ -86,10 +85,10 @@ describe "Creating a new agent", js: true do
     end
 
     it "does not send previously configured receivers when the current agent does not support them" do
-      select2("Website Agent scrapes", from: "Type")
+      select_agent_type("Website Agent scrapes")
       sleep 0.5
       select2("ZKCD", from: 'Receivers')
-      select2("Email Agent", from: "Type")
+      select_agent_type("Email Agent")
       fill_in(:agent_name, with: "No receivers")
       click_on "Save"
       expect(page).to have_content("No receivers")

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,0 +1,9 @@
+module FeatureHelpers
+  def select_agent_type(type)
+    select2(type, from: "Type")
+
+    # Wait for all parts of the Agent form to load:
+    expect(page).to have_css("div.function_buttons") # Options editor
+    expect(page).to have_css(".well.description > p") # Markdown description
+  end
+end


### PR DESCRIPTION
I was seeing intermittent Capybara failures when playing with @knu's #1876. I believe this change helps by ensuring that Capybara waits for the full Agent form to be available before interacting further.