### PR TITLE
Fix multi-process image when not specifying  POSTGRES_PORT_5432_TCP_ADDR

### DIFF
--- a/docker/multi-process/README.md
+++ b/docker/multi-process/README.md
@@ -33,6 +33,8 @@ Additionally, the database variables may be overridden from the above as per the
     DATABASE_HOST
     DATABASE_PORT
 
+When connecting to an external database and your user does not have the permission to create the Huginn database please make sure it exists and set the `DO_NOT_CREATE_DATABASE` environment variable.
+
 This script will run database migrations (rake db:migrate) which should be idempotent.
 
 It will also seed the database (rake db:seed) unless this is defined:

--- a/docker/multi-process/scripts/init
+++ b/docker/multi-process/scripts/init
@@ -198,7 +198,9 @@ if [ -n "\${DATABASE_INITIAL_CONNECT_MAX_RETRIES}" ]; then
 fi
 
 # We may need to try and create a database
-sudo -u huginn -EH bundle exec rake db:create
+if [ -z "\${DO_NOT_CREATE_DATABASE}" ]; then
+  sudo -u huginn -EH bundle exec rake db:create
+fi
 
 # Assuming we have a created database, run the migrations and seed it idempotently.
 if [ -z "\${DO_NOT_MIGRATE}" ]; then

--- a/docker/multi-process/scripts/init
+++ b/docker/multi-process/scripts/init
@@ -13,12 +13,12 @@ fi
 # is a mysql or postgresql database linked?
 # requires that the mysql or postgresql containers have exposed
 # port 3306 and 5432 respectively.
-if [ -n "${MYSQL_PORT_3306_TCP_ADDR}" ]; then
+if [[ -n "${MYSQL_PORT_3306_TCP_ADDR}" || ("${DATABASE_ADAPTER}" == "mysql2" && -n "${DATABASE_HOST}") ]]; then
   DATABASE_ADAPTER=${DATABASE_ADAPTER:-mysql2}
   DATABASE_HOST=${DATABASE_HOST:-${MYSQL_PORT_3306_TCP_ADDR}}
   DATABASE_PORT=${DATABASE_PORT:-${MYSQL_PORT_3306_TCP_PORT}}
   DATABASE_ENCODING=${DATABASE_ENCODING:-utf8mb4}
-elif [ -n "${POSTGRES_PORT_5432_TCP_ADDR}" ]; then
+elif [[ -n "${POSTGRES_PORT_5432_TCP_ADDR}" || "${DATABASE_ADAPTER}" == "postgresql" ]]; then
   DATABASE_ADAPTER=${DATABASE_ADAPTER:-postgresql}
   DATABASE_HOST=${DATABASE_HOST:-${POSTGRES_PORT_5432_TCP_ADDR}}
   DATABASE_PORT=${DATABASE_PORT:-${POSTGRES_PORT_5432_TCP_PORT}}

--- a/docker/single-process/README.md
+++ b/docker/single-process/README.md
@@ -26,6 +26,8 @@ Additionally, the database variables may be overridden from the above as per the
     DATABASE_HOST
     DATABASE_PORT
 
+If your database user does not have the permission to create the Huginn database please make sure it exists and set the `DO_NOT_CREATE_DATABASE` environment variable.
+
 This script will run database migrations (rake db:migrate) which should be idempotent.
 
 It will also seed the database (rake db:seed) unless this is defined:

--- a/docker/single-process/scripts/init
+++ b/docker/single-process/scripts/init
@@ -44,8 +44,12 @@ esac
 
 sudo -u huginn -H -E bundle install --without test development --path vendor/bundle
 
+if [[ -z "${DO_NOT_CREATE_DATABASE}" && -z $1 ]]; then
+  sudo -u huginn -H -E bundle exec rake db:create RAILS_ENV=${RAILS_ENV}
+fi
+
 if [ -z $1 ]; then
-  sudo -u huginn -H -E bundle exec rake db:create db:migrate RAILS_ENV=${RAILS_ENV}
+  sudo -u huginn -H -E bundle exec rake db:migrate RAILS_ENV=${RAILS_ENV}
 fi
 
 if [[ -z "${DO_NOT_SEED}" && -z $1 ]]; then


### PR DESCRIPTION
When `DATABASE_ADAPTER` is set to `postgresql` we do not need to start
the internal mysql daemon. The same is true when `DATABASE_ADAPTER` is
set to `mysql2` and `DATABASE_HOST` is set.

Fixes #1921