### PR TITLE
Close #801 - peak detector min datapoints

### DIFF
--- a/db/migrate/20170307190555_add_min_events_option_to_peak_detector_agents.rb
+++ b/db/migrate/20170307190555_add_min_events_option_to_peak_detector_agents.rb
@@ -1,0 +1,19 @@
+class AddMinEventsOptionToPeakDetectorAgents < ActiveRecord::Migration[5.0]
+  def up
+    Agents::PeakDetectorAgent.find_each do |agent|
+      if agent.options['min_events'].nil?
+        agent.options['min_events'] = '4'
+        agent.save(validate: false)
+      end
+    end
+  end
+
+  def down
+    Agents::PeakDetectorAgent.find_each do |agent|
+      if agent.options['min_events'].present?
+        agent.options.delete 'min_events'
+        agent.save(validate: false)
+      end
+    end
+  end
+end

--- a/spec/models/agents/peak_detector_agent_spec.rb
+++ b/spec/models/agents/peak_detector_agent_spec.rb
@@ -8,7 +8,8 @@ describe Agents::PeakDetectorAgent do
           'expected_receive_period_in_days' => "2",
           'group_by_path' => "filter",
           'value_path' => "count",
-          'message' => "A peak was found"
+          'message' => "A peak was found",
+          'min_events' => "4",
         }
     }
 
@@ -67,6 +68,15 @@ describe Agents::PeakDetectorAgent do
                                   :values => [1, 1, 1, 1, 1, 1, 10, 1, 1, 1, 1, 1, 1, 1, 10, 1].map {|i| [i]},
                                   :pattern => { 'filter' => "something" })
       expect(@agent.memory['peaks']['something'].length).to eq(2)
+    end
+
+    it 'waits and accumulates min events before triggering for peaks' do
+      @agent.options['min_peak_spacing_in_days'] = 1/24.0
+      @agent.options['min_events'] = '10'
+      @agent.receive build_events(:keys => ['count'],
+                                  :values => [1, 1, 1, 1, 1, 1, 10, 1, 1, 1, 1, 1, 1, 1, 10, 1].map {|i| [i]},
+                                  :pattern => { 'filter' => "something" })
+      expect(@agent.memory['peaks']['something'].length).to eq(1)
     end
   end
 


### PR DESCRIPTION
Closes -- https://github.com/cantino/huginn/issues/801
Testing -- ran rspec
About --
  Adds an option `min_events` to the peak detector agent. The
  agent will start looking for peaks only after min number of
  events are accumulated.