### PR TITLE
docker: generate Rails secret at first run if not configured

### DIFF
--- a/docker/multi-process/scripts/init
+++ b/docker/multi-process/scripts/init
@@ -5,6 +5,14 @@ export LC_ALL=en_US.UTF-8
 
 cd /app
 
+# Do we have a Rails secret yet?
+# If not, generate one, but persist it for the container's lifetime.
+if [ -z "$APP_SECRET_TOKEN" ] && grep -q ^APP_SECRET_TOKEN=REPLACE_ME_NOW .env.example; then
+  echo 'Generating random APP_SECRET_TOKEN.'
+  secret=$(dd if=/dev/urandom bs=36 count=1 | openssl base64)
+  sed -i.orig "s:REPLACE_ME_NOW:$secret:" .env.example
+fi
+
 # Cleanup any leftover pid file
 if [ -f /app/tmp/pids/server.pid ]; then
   rm /app/tmp/pids/server.pid

--- a/docker/single-process/scripts/init
+++ b/docker/single-process/scripts/init
@@ -5,6 +5,14 @@ export LC_ALL=en_US.UTF-8
 
 cd /app
 
+# Do we have a Rails secret yet?
+# If not, generate one, but persist it for the container's lifetime.
+if [ -z "$APP_SECRET_TOKEN" ] && grep -q ^APP_SECRET_TOKEN=REPLACE_ME_NOW .env.example; then
+  echo 'Generating random APP_SECRET_TOKEN.'
+  secret=$(dd if=/dev/urandom bs=36 count=1 | openssl base64)
+  sed -i.orig "s:REPLACE_ME_NOW:$secret:" .env.example
+fi
+
 # Configure database based on linked container
 if [ -n "${MYSQL_PORT_3306_TCP_ADDR}" ]; then
   DATABASE_ADAPTER=${DATABASE_ADAPTER:-mysql2}


### PR DESCRIPTION
Currently, the default Docker builds leave the Rails secret as `REPLACE_ME_NOW!`. This is less than ideal. Since this is used to verify browser requests, we need to generate one on first run after `docker run` (and keep it the same for the lifetime of the container, that is, replace it in `.env.example`).

If the container is destroyed and re-created with `docker run` using the same backing storage, this will invalidate existing sessions and require logging in again -- which IMO seems like a good idea anyway.