### PR TITLE
docker: DEBIAN_FRONTEND was missing "export"

### DIFF
--- a/docker/multi-process/scripts/standalone-packages
+++ b/docker/multi-process/scripts/standalone-packages
@@ -1,4 +1,4 @@
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y python2.7 python-docutils mysql-server \
                    supervisor python-pip && \


### PR DESCRIPTION
Tiny nitpick, but reduces the apt-get warnings during `docker build`.