### PR TITLE
user: allow the administrator to disable self-signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,11 @@ FORCE_SSL=false
 #     User authentication and registration     #
 ################################################
 
+# To prevent new users from signing up, requiring an administrator to create accounts, set this to true.
+DISABLE_SIGNUP=false
+
 # This invitation code will be required for users to signup with your Huginn installation.
-# You can see its use in user.rb.  PLEASE CHANGE THIS!
+# You can see its use in user.rb.  PLEASE CHANGE THIS (or change DISABLE_SIGNUP to true)!
 INVITATION_CODE=try-huginn
 
 # If you don't want to require new users to have an invitation code in order to sign up, set this to true.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ActiveRecord::Base
   validates_presence_of :username
   validates :username, uniqueness: { case_sensitive: false }
   validates_format_of :username, :with => /\A[a-zA-Z0-9_-]{3,15}\Z/, :message => "can only contain letters, numbers, underscores, and dashes, and must be between 3 and 15 characters in length."
-  validates_inclusion_of :invitation_code, :on => :create, :in => INVITATION_CODES, :message => "is not valid", if: -> { !requires_no_invitation_code? && User.using_invitation_code? }
+  validates_inclusion_of :invitation_code, :on => :create, :in => INVITATION_CODES, :message => "is not valid", if: -> { !requires_no_invitation_code? && User.using_invitation_code? && User.allow_signup? }
 
   has_many :user_credentials, :dependent => :destroy, :inverse_of => :user
   has_many :events, -> { order("events.created_at desc") }, :dependent => :delete_all, :inverse_of => :user
@@ -62,6 +62,10 @@ class User < ActiveRecord::Base
 
   def inactive_message
     active? ? super : :deactivated_account
+  end
+
+  def self.allow_signup?
+    ENV['DISABLE_SIGNUP'] != 'true'
   end
 
   def self.using_invitation_code?

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,20 +7,22 @@
 
         <h2>Sign up</h2>
 
-        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
-          <%= devise_error_messages! %>
-          <% if ENV['ON_HEROKU'] && User.count.zero? %>
-          <div class="heroku-instructions">
-            <% app_name = request.host[/\A[^.]+/] %>
-            <p>If you are the owner of this application, take the following steps to complete the setup:</p>
+        <% if User.allow_signup? %>
 
-            <ul>
-              <li>Read <a href="https://github.com/cantino/huginn/wiki/Run-Huginn-for-free-on-Heroku" target="_target">this document</a> carefully if you are going to try out Huginn for free on <a href="https://id.heroku.com/" target="_target">Heroku</a>.</li>
+          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
+            <%= devise_error_messages! %>
+            <% if ENV['ON_HEROKU'] && User.count.zero? %>
+            <div class="heroku-instructions">
+              <% app_name = request.host[/\A[^.]+/] %>
+              <p>If you are the owner of this application, take the following steps to complete the setup:</p>
 
-              <li>Install the <a href="https://toolbelt.heroku.com/" target="_target">Heroku Toolbelt</a> and run <kbd>heroku login</kbd>, if you haven't already.</li>
+              <ul>
+                <li>Read <a href="https://github.com/cantino/huginn/wiki/Run-Huginn-for-free-on-Heroku" target="_target">this document</a> carefully if you are going to try out Huginn for free on <a href="https://id.heroku.com/" target="_target">Heroku</a>.</li>
 
-              <li>Run the following commands:<br />
-                <%= content_tag :pre do -%>
+                <li>Install the <a href="https://toolbelt.heroku.com/" target="_target">Heroku Toolbelt</a> and run <kbd>heroku login</kbd>, if you haven't already.</li>
+
+                <li>Run the following commands:<br />
+                  <%= content_tag :pre do -%>
 git clone https://github.com/cantino/huginn.git <%= content_tag :var, app_name %>
 cd <%= content_tag :var, app_name %>
 heroku git:remote -a <%= content_tag :var, app_name %>
@@ -30,32 +32,36 @@ bundle
 bin/setup_heroku
 <%- end %>
 
-              <li>This command will create an admin account for you.</li>
-            </ul>
-          </div>
-          <% end %>
+                <li>This command will create an admin account for you.</li>
+              </ul>
+            </div>
+            <% end %>
 
-          <% if User.using_invitation_code? %>
+            <% if User.using_invitation_code? %>
+              <div class="form-group">
+                <%= f.label :invitation_code, class: 'col-md-4 control-label' %>
+                <div class="col-md-6">
+                  <%= f.text_field :invitation_code, class: 'form-control' %>
+                  <span class="help-inline">We are not yet open to the public.  If you have an invitation code, please enter it here.</span>
+                </div>
+              </div>
+            <% end %>
+
+            <%= render partial: 'common_registration_fields', locals: { f: f } %>
+
             <div class="form-group">
-              <%= f.label :invitation_code, class: 'col-md-4 control-label' %>
-              <div class="col-md-6">
-                <%= f.text_field :invitation_code, class: 'form-control' %>
-                <span class="help-inline">We are not yet open to the public.  If you have an invitation code, please enter it here.</span>
+              <div class="col-md-offset-4 col-md-10">
+                <%= f.submit "Sign up", class: "btn btn-primary" %>
               </div>
             </div>
+
           <% end %>
 
-          <%= render partial: 'common_registration_fields', locals: { f: f } %>
+          <%= render "devise/shared/links" %>
 
-          <div class="form-group">
-            <div class="col-md-offset-4 col-md-10">
-              <%= f.submit "Sign up", class: "btn btn-primary" %>
-            </div>
-          </div>
-
+        <% else %>
+          Self-signup is disabled. Please ask your administrator to create an account.
         <% end %>
-
-        <%= render "devise/shared/links" %>
       </div>
     </div>
   </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Log in", new_session_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+<%- if devise_mapping.registerable? && controller_name != 'registrations' && User.allow_signup? %>
   <%= link_to "Sign up", new_registration_path(resource_name) %><br />
 <% end -%>
 

--- a/app/views/home/_signed_out_index.html.erb
+++ b/app/views/home/_signed_out_index.html.erb
@@ -7,7 +7,9 @@
       <p>Huginn monitors the world and acts on your behalf.</p>
 
       <%= link_to "Login", new_user_session_path, :class => "btn btn-large" %>
-      <%= link_to "Signup", new_user_registration_path, :class => "btn btn-primary btn-large" %>
+      <% if User.allow_signup? %>
+        <%= link_to "Signup", new_user_registration_path, :class => "btn btn-primary btn-large" %>
+      <% end %>
     </div>
     
     <div class="col-md-3 col-md-offset-1">

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -74,7 +74,7 @@
         <li>
           <% if user_signed_in? %>
             <%= link_to 'Account', edit_user_registration_path, :tabindex => "-1" %>
-          <% else %>
+          <% elsif User.allow_signup? %>
             <%= link_to 'Sign up', new_user_registration_path, :tabindex => "-1" %>
           <% end %>
         </li>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,18 @@ describe User do
         end
       end
       
+      context "when configured to prevent signup" do
+        before do
+          stub(User).allow_signup? {false}
+        end
+
+        it "rejects all invitation codes" do
+          User::INVITATION_CODES.each do |v|
+            should_not allow_value(v).for(:invitation_code)
+          end
+        end
+      end
+
       context "when configured not to use invitation codes" do
         before do
           stub(User).using_invitation_code? {false}


### PR DESCRIPTION
As this is my first Ruby-code contribution, please lmk if I've missed any important steps here. I did add a spec validation for this use case.

[Commit detail message follows]
Closed installations, where users are strictly controlled, don't want
to offer self-signup at all. Allow this to be prevented (making
INVITATION_CODE and related values moot) by setting DISABLE_SIGNUP=true.