### PR TITLE
Fix View diagram : Too many agent to display (#1664)

### DIFF
--- a/app/helpers/dot_helper.rb
+++ b/app/helpers/dot_helper.rb
@@ -8,14 +8,25 @@ module DotHelper
         } rescue false)
       decorate_svg(svg, agents).html_safe
     else
-      uriquery = URI.encode_www_form(cht: 'gv', chl: agents_dot(agents))
-      #Get query maximum length should be under 2048 bytes with including "chart?" of google chart request url
-      if uriquery.length > 2042
-        "Too many agent to display, please check unused agents"
+      # Google chart request url
+      url = URI("https://chart.googleapis.com/chart")
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      request = Net::HTTP::Post.new(url)
+      request.body = URI.encode_www_form(cht: 'gv', chl: agents_dot(agents))
+      response = http.request(request)
+
+
+      if response.code=='200'
+        # Display Base64-Encoded images
+        tag('img', src: 'data:image/jpg;base64,'+Base64.encode64(response.read_body))
+      elsif response.code=='400'
+        "The diagram can't be displayed because it has too many nodes. Max allowed is 80."
+      elsif response.code=='413'
+        "The diagram can't be displayed because it is too large."
       else
-        tag('img', src: URI('https://chart.googleapis.com/chart').tap { |uri|
-              uri.query = uriquery
-	    })
+        "Unknow error. Response code is "+response.code
       end
     end
   end


### PR DESCRIPTION
Making a GET request is simple, but GET URLs are limited to 2K characters.
The Google Chart API supports HTTP POST for chart requests up to 16K long. (*1)

(*1) https://developers.google.com/chart/image/docs/post_requests