### PR TITLE
Close #1914 - remove 'become user' if deactivated user

### DIFF
--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -22,7 +22,7 @@
 <div class="row">
   <div class="col-md-12">
     <%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, admin_users_path, class: "btn btn-default" %>
-    <% if @user.persisted? %>
+    <% if @user.persisted? && @user.active? && @user != current_user %>
       <%= link_to 'Become User', switch_to_user_admin_user_path(@user), class: "btn btn-default btn-info", data: { confirm: 'This will log you in as another user. Would you like to continue?' } %>
     <% end %>
   </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -32,8 +32,8 @@
               <td>
                 <div class="btn-group btn-group-xs">
                   <% if user != current_user %>
-                    <%= link_to 'Become User', switch_to_user_admin_user_path(user), class: "btn btn-default", data: { confirm: 'This will log you in as another user. Would you like to continue?' } %>
                     <% if user.active? %>
+                      <%= link_to 'Become User', switch_to_user_admin_user_path(user), class: "btn btn-default", data: { confirm: 'This will log you in as another user. Would you like to continue?' } %>
                       <%= link_to 'Deactivate', deactivate_admin_user_path(user), method: :put, class: "btn btn-default" %>
                     <% else %>
                       <%= link_to 'Activate', activate_admin_user_path(user), method: :put, class: "btn btn-default" %>


### PR DESCRIPTION
Ticket -- https://github.com/cantino/huginn/issues/1914
Testing -- Local huginn setup
About --
Switching as admin to a user is broken if the user is deactivated.

This code makes the 'Become User' buttons invisible if the user to
be impersonated is deactivated. The buttons used to be visible on:
* /admin/users
* /admin/users/XX/edit

Bonus: removes the 'Become User' button from the 'Edit Users' page
if we are the edited `current_user`.