### PR TITLE
Add HUGINN_AGENT_SPEC_RUNNER helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,3 +203,17 @@ end
 GemfileHelper.parse_each_agent_gem(ENV['ADDITIONAL_GEMS']) do |args|
   gem *args
 end
+
+if ENV['HUGINN_AGENT_SPEC_RUNNER']
+  base_path = File.expand_path('../../../', __FILE__)
+  gemspec = Dir["#{base_path}/*.gemspec"].first
+  previous_gems = Hash[dependencies.map { |dep| [dep.name, dep] }]
+  Gem::Specification.load(gemspec).development_dependencies.each do |args|
+    previous_gem = previous_gems[args.name]
+    if previous_gem
+      abort "Gem #{args.to_s} in #{gemspec} conflicts with huginn/Gemfile" unless previous_gem.match?(args.to_spec)
+    else
+      gem args.name, *args.requirements_list
+    end
+  end
+end


### PR DESCRIPTION
Changes:
- When `HUGINN_AGENT_SPEC_RUNNER` is set - load the `huginn_agent.gemspec`. This allows the gemspec development dependencies to be loaded when running `rake spec` from `huginn_agent`

Fixes:
https://github.com/cantino/huginn_agent/issues/13

Blocks:
https://github.com/cantino/huginn_agent/pull/15