### PR TITLE
Update Nokogiri to 1.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
       kaminari (>= 0.13)
       rails (>= 3.1)
     buftok (0.2.0)
-    builder (3.2.2)
+    builder (3.2.3)
     byebug (8.2.5)
     capistrano (3.4.0)
       i18n
@@ -159,7 +159,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     colorize (0.7.7)
-    concurrent-ruby (1.0.3)
+    concurrent-ruby (1.0.5)
     cookiejar (0.3.2)
     coveralls (0.7.12)
       multi_json (~> 1.10)
@@ -182,7 +182,7 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
@@ -290,9 +290,9 @@ GEM
     hypdf (1.0.10)
       httmultiparty (~> 0.3)
       httparty (~> 0.13)
-    i18n (0.7.0)
+    i18n (0.8.1)
     jmespath (1.1.3)
-    jquery-rails (4.2.1)
+    jquery-rails (4.2.2)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -343,7 +343,7 @@ GEM
     net-ssh (3.0.2)
     netrc (0.10.3)
     nio4r (1.2.1)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.0.8)
       nenv (~> 0.1)
@@ -420,9 +420,9 @@ GEM
       actionpack (~> 5.x)
       actionview (~> 5.x)
       activesupport (~> 5.x)
-    rails-dom-testing (2.0.1)
+    rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
     railties (5.0.1)
@@ -453,12 +453,12 @@ GEM
       rspec-mocks (~> 3.5.0)
     rspec-collection_matchers (1.1.2)
       rspec-expectations (>= 2.99.0.beta1)
-    rspec-core (3.5.2)
+    rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
-    rspec-html-matchers (0.8.1)
+    rspec-html-matchers (0.9.1)
       nokogiri (~> 1)
       rspec (>= 3.0.0.a, < 4)
     rspec-mocks (3.5.0)
@@ -534,7 +534,7 @@ GEM
       libv8 (~> 3.16.14.0)
       ref
     thor (0.19.4)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tilt (2.0.5)
     tins (1.10.1)
     treetop (1.5.3)
@@ -702,7 +702,7 @@ DEPENDENCIES
   xmpp4r (~> 0.5.6)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.7
+   1.14.6


### PR DESCRIPTION
Update Nokogiri because of [CVE-2016-4658](https://hakiri.io/technologies/nokogiri/issues/327b51c9fa5fe5).