### PR TITLE
Set created_at of dry-runned event to the current time

### DIFF
--- a/app/controllers/agents/dry_runs_controller.rb
+++ b/app/controllers/agents/dry_runs_controller.rb
@@ -35,7 +35,7 @@ module Agents
         if event_payload = params[:event]
           dummy_agent = Agent.build_for_type('ManualEventAgent', current_user, name: 'Dry-Runner')
           dummy_agent.readonly!
-          event = dummy_agent.events.build(user: current_user, payload: event_payload)
+          event = dummy_agent.events.build(user: current_user, payload: event_payload, created_at: Time.now)
         end
 
         @results = agent.dry_run!(event)

--- a/spec/controllers/agents/dry_runs_controller_spec.rb
+++ b/spec/controllers/agents/dry_runs_controller_spec.rb
@@ -117,5 +117,15 @@ describe Agents::DryRunsController do
       expect(results[:events][0]).to eql({"message" => "bar"})
     end
 
+    it 'sets created_at of the dry-runned event' do
+      agent = agents(:bob_formatting_agent)
+      agent.options['instructions'] = {'created_at' => '{{created_at | date: "%a, %b %d, %y"}}'}
+      agent.save
+      post :create, params: {agent_id: agent, event: {test: 1}.to_json}
+      results = assigns(:results)
+      expect(results[:events]).to be_a(Array)
+      expect(results[:events].length).to eq(1)
+      expect(results[:events].first['created_at']).to eq('Tue, Apr 11, 17')
+    end
   end
 end


### PR DESCRIPTION
Allows the usage of `{{created_at}}` when dry-running Agents.

 #1964