### PR TITLE
Option for custom response headers for receive_web_request

### DIFF
--- a/app/controllers/web_requests_controller.rb
+++ b/app/controllers/web_requests_controller.rb
@@ -28,7 +28,7 @@ class WebRequestsController < ApplicationController
       if agent
         content, status, content_type, headers = agent.trigger_web_request(request)
 
-        if headers.presence
+        if headers.present?
           headers.each do |k,v|
             response.headers[k] = v
           end

--- a/app/controllers/web_requests_controller.rb
+++ b/app/controllers/web_requests_controller.rb
@@ -9,11 +9,13 @@
 # #receive_web_request is called. For example, one of your Agent's options could be :secret and you could compare this
 # value to params[:secret] whenever #receive_web_request is called on your Agent, rejecting invalid requests.
 #
-# Your Agent's #receive_web_request method should return an Array of json_or_string_response, status_code, and
-# optional mime type.  For example:
+# Your Agent's #receive_web_request method should return an Array of json_or_string_response, status_code, 
+# optional mime type, and optional hash of custom response headers.  For example:
 #   [{status: "success"}, 200]
 # or
 #   ["not found", 404, 'text/plain']
+# or
+#   ["<status>success</status>", 200, 'text/xml', {"Access-Control-Allow-Origin" => "*"}]
 
 class WebRequestsController < ApplicationController
   skip_before_action :verify_authenticity_token
@@ -24,7 +26,13 @@ class WebRequestsController < ApplicationController
     if user
       agent = user.agents.find_by_id(params[:agent_id])
       if agent
-        content, status, content_type = agent.trigger_web_request(request)
+        content, status, content_type, headers = agent.trigger_web_request(request)
+
+        if headers.presence
+          headers.each do |k,v|
+            response.headers[k] = v
+          end
+        end
 
         status = status || 200
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -96,7 +96,7 @@ class Agent < ActiveRecord::Base
 
   def receive_web_request(params, method, format)
     # Implement me in your subclass of Agent.
-    ["not implemented", 404]
+    ["not implemented", 404, "text/plain", {}] # last two elements in response array are optional
   end
 
   # alternate method signature for receive_web_request

--- a/app/models/agents/data_output_agent.rb
+++ b/app/models/agents/data_output_agent.rb
@@ -28,6 +28,7 @@ module Agents
           * `ns_media` - Add [yahoo media namespace](https://en.wikipedia.org/wiki/Media_RSS) in output xml
           * `ns_itunes` - Add [itunes compatible namespace](http://lists.apple.com/archives/syndication-dev/2005/Nov/msg00002.html) in output xml
           * `rss_content_type` - Content-Type for RSS output (default: `application/rss+xml`)
+          * `response_headers` - A JSON object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
           * `push_hubs` - Set to a list of PubSubHubbub endpoints you want to publish an update to every time this agent receives an event. (default: none)  Popular hubs include [Superfeedr](https://pubsubhubbub.superfeedr.com/) and [Google](https://pubsubhubbub.appspot.com/).  Note that publishing updates will make your feed URL known to the public, so if you want to keep it secret, set up a reverse proxy to serve your feed via a safe URL and specify it in `template.self`.
 
         If you'd like to output RSS tags with attributes, such as `enclosure`, use something like the following in your `template`:
@@ -278,7 +279,7 @@ module Agents
             'items' => simplify_item_for_json(items)
           }
 
-          return [content, 200]
+          return [content, 200, "application/json", interpolated['response_headers'].presence]
         else
           hub_links = push_hubs.map { |hub|
             <<-XML
@@ -290,7 +291,7 @@ module Agents
                   .to_xml(skip_types: true, root: "items", skip_instruct: true, indent: 1)
                   .gsub(%r{^</?items>\n}, '')
 
-          return [<<-XML, 200, rss_content_type]
+          return [<<-XML, 200, rss_content_type, interpolated['response_headers'].presence]
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" #{xml_namespace}>
 <channel>

--- a/app/models/agents/data_output_agent.rb
+++ b/app/models/agents/data_output_agent.rb
@@ -28,7 +28,7 @@ module Agents
           * `ns_media` - Add [yahoo media namespace](https://en.wikipedia.org/wiki/Media_RSS) in output xml
           * `ns_itunes` - Add [itunes compatible namespace](http://lists.apple.com/archives/syndication-dev/2005/Nov/msg00002.html) in output xml
           * `rss_content_type` - Content-Type for RSS output (default: `application/rss+xml`)
-          * `response_headers` - A JSON object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
+          * `response_headers` - An object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
           * `push_hubs` - Set to a list of PubSubHubbub endpoints you want to publish an update to every time this agent receives an event. (default: none)  Popular hubs include [Superfeedr](https://pubsubhubbub.superfeedr.com/) and [Google](https://pubsubhubbub.appspot.com/).  Note that publishing updates will make your feed URL known to the public, so if you want to keep it secret, set up a reverse proxy to serve your feed via a safe URL and specify it in `template.self`.
 
         If you'd like to output RSS tags with attributes, such as `enclosure`, use something like the following in your `template`:

--- a/app/models/agents/liquid_output_agent.rb
+++ b/app/models/agents/liquid_output_agent.rb
@@ -23,7 +23,7 @@ module Agents
           * `expected_receive_period_in_days` - How often you expect data to be received by this Agent from other Agents.
           * `content` - The content to display when someone requests this page.
           * `mime_type` - The mime type to use when someone requests this page.
-          * `response_headers` - A JSON object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
+          * `response_headers` - An object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
           * `mode` - The behavior that determines what data is passed to the Liquid template.
           * `event_limit` - A limit applied to the events passed to a template when in "Last X events" mode. Can be a count like "1", or an amount of time like "1 day" or "5 minutes".
 

--- a/app/models/agents/liquid_output_agent.rb
+++ b/app/models/agents/liquid_output_agent.rb
@@ -23,6 +23,7 @@ module Agents
           * `expected_receive_period_in_days` - How often you expect data to be received by this Agent from other Agents.
           * `content` - The content to display when someone requests this page.
           * `mime_type` - The mime type to use when someone requests this page.
+          * `response_headers` - A JSON object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
           * `mode` - The behavior that determines what data is passed to the Liquid template.
           * `event_limit` - A limit applied to the events passed to a template when in "Last X events" mode. Can be a count like "1", or an amount of time like "1 day" or "5 minutes".
 
@@ -151,7 +152,7 @@ EOF
     end
 
     def receive_web_request(params, method, format)
-      valid_authentication?(params) ? [liquified_content, 200, mime_type]
+      valid_authentication?(params) ? [liquified_content, 200, mime_type, interpolated['response_headers'].presence]
                                     : [unauthorized_content(format), 401]
     end
 

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -26,7 +26,7 @@ module Agents
           For example, "post,get" will enable POST and GET requests. Defaults
           to "post".
         * `response` - The response message to the request. Defaults to 'Event Created'.
-        * `response_headers` - A JSON object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
+        * `response_headers` - An object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
         * `code` - The response code to the request. Defaults to '201'. If the code is '301' or '302' the request will automatically be redirected to the url defined in "response".
         * `recaptcha_secret` - Setting this to a reCAPTCHA "secret" key makes your agent verify incoming requests with reCAPTCHA.  Don't forget to embed a reCAPTCHA snippet including your "site" key in the originating form(s).
         * `recaptcha_send_remote_addr` - Set this to true if your server is properly configured to set REMOTE_ADDR to the IP address of each visitor (instead of that of a proxy server).

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -26,6 +26,7 @@ module Agents
           For example, "post,get" will enable POST and GET requests. Defaults
           to "post".
         * `response` - The response message to the request. Defaults to 'Event Created'.
+        * `response_headers` - A JSON object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
         * `code` - The response code to the request. Defaults to '201'. If the code is '301' or '302' the request will automatically be redirected to the url defined in "response".
         * `recaptcha_secret` - Setting this to a reCAPTCHA "secret" key makes your agent verify incoming requests with reCAPTCHA.  Don't forget to embed a reCAPTCHA snippet including your "site" key in the originating form(s).
         * `recaptcha_send_remote_addr` - Set this to true if your server is properly configured to set REMOTE_ADDR to the IP address of each visitor (instead of that of a proxy server).
@@ -88,7 +89,11 @@ module Agents
         create_event(payload: payload)
       end
 
-      [interpolated(params)['response'] || 'Event Created', code]
+      if interpolated['response_headers'].presence
+        [interpolated(params)['response'] || 'Event Created', code, "text/plain", interpolated['response_headers'].presence]
+      else
+        [interpolated(params)['response'] || 'Event Created', code]
+      end
     end
 
     def working?

--- a/spec/controllers/web_requests_controller_spec.rb
+++ b/spec/controllers/web_requests_controller_spec.rb
@@ -10,7 +10,7 @@ describe WebRequestsController do
         memory[:web_request_values] = params
         memory[:web_request_format] = format
         memory[:web_request_method] = method
-        ["success", (options[:status] || 200).to_i, memory['content_type']]
+        ["success", (options[:status] || 200).to_i, memory['content_type'], memory['response_headers']]
       else
         ["failure", 404]
       end
@@ -83,6 +83,21 @@ describe WebRequestsController do
     @agent.save!
     get :handle_request, params: {:user_id => users(:bob).to_param, :agent_id => @agent.id, :secret => "my_secret", :key => "value", :another_key => "5"}
     expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+  end
+
+  it "can accept custom response headers to return" do
+    @agent.memory['response_headers'] = {"Access-Control-Allow-Origin" => "*"}
+    @agent.save!
+    get :handle_request, params: {:user_id => users(:bob).to_param, :agent_id => @agent.id, :secret => "my_secret", :key => "value", :another_key => "5"}
+    expect(response.headers['Access-Control-Allow-Origin']).to eq('*')
+  end
+
+  it "can accept multiple custom response headers to return" do
+    @agent.memory['response_headers'] = {"Access-Control-Allow-Origin" => "*", "X-My-Custom-Header" => "hello"}
+    @agent.save!
+    get :handle_request, params: {:user_id => users(:bob).to_param, :agent_id => @agent.id, :secret => "my_secret", :key => "value", :another_key => "5"}
+    expect(response.headers['Access-Control-Allow-Origin']).to eq('*')
+    expect(response.headers['X-My-Custom-Header']).to eq('hello')
   end
 
   it 'should redirect correctly' do

--- a/spec/models/agents/data_output_agent_spec.rb
+++ b/spec/models/agents/data_output_agent_spec.rb
@@ -193,7 +193,7 @@ describe Agents::DataOutputAgent do
         XML
       end
 
-      describe "with cumstom rss_content_type given" do
+      describe "with custom rss_content_type given" do
         before do
           agent.options['rss_content_type'] = 'text/xml'
           agent.save!
@@ -253,6 +253,19 @@ describe Agents::DataOutputAgent do
             }
           ]
         })
+      end
+
+      describe "with custom response_headers given" do
+        before do
+          agent.options['response_headers'] = {"Access-Control-Allow-Origin" => "*", "X-My-Custom-Header" => "hello"}
+          agent.save!
+        end
+
+        it "can respond with custom headers" do
+          content, status, content_type, response_headers = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
+          expect(status).to eq(200)
+          expect(response_headers).to eq({"Access-Control-Allow-Origin" => "*", "X-My-Custom-Header" => "hello"})
+        end
       end
 
       context 'with more events' do

--- a/spec/models/agents/liquid_output_agent_spec.rb
+++ b/spec/models/agents/liquid_output_agent_spec.rb
@@ -224,6 +224,12 @@ describe Agents::LiquidOutputAgent do
       agents(:bob_website_agent).events.destroy_all
     end
 
+    it 'should respond with custom response header if configured with `response_headers` option' do
+      agent.options['response_headers'] = {"X-My-Custom-Header" => 'hello'}
+      result = agent.receive_web_request params, method, format
+      expect(result).to eq(["The key is #{value}.", 200, mime_type, {"X-My-Custom-Header" => "hello"}])
+    end
+
     describe "and the mode is last event in" do
 
       before { agent.options['mode'] = 'Last event in' }

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -55,6 +55,12 @@ describe Agents::WebhookAgent do
       expect(out).to eq(['jon', 201])
     end
 
+    it 'should respond with custom response header if configured with `response_headers` option' do
+      agent.options['response_headers'] = {"X-My-Custom-Header" => 'hello'}
+      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      expect(out).to eq(['Event Created', 201, "text/plain", {"X-My-Custom-Header" => 'hello'}])
+    end
+
     it 'should respond with `Event Created` if the response option is nil or missing' do
       agent.options['response'] = nil
       out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")


### PR DESCRIPTION
In DataOutputAgent, WebhookAgent, LiquidOutputAgent, this enables setting `options['response_headers']` as a JSON object with custom response headers to set on the HTTP response through the WebRequestsController.

Should provide a solution for https://github.com/cantino/huginn/issues/1295 and also setting CORS headers for DataOutputAgent.